### PR TITLE
Add debian:jessie support for 1.7.10

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:jessie
+
+MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
+
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN echo "deb http://nginx.org/packages/mainline/debian/ wheezy nginx" >> /etc/apt/sources.list
+
+ENV NGINX_VERSION 1.7.10-1~wheezy
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates nginx=${NGINX_VERSION} && \
+    rm -rf /var/lib/apt/lists/*
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log
+RUN ln -sf /dev/stderr /var/log/nginx/error.log
+
+VOLUME ["/var/cache/nginx"]
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
A lot of official programming language run-times such as
Golang, Ruby and NodeJS use Jessie as a base rather than
Wheezy.

To ensure the footprint remains as small as it can be this
patch allows you to optionally pick Jessie.