### PR TITLE
Use http for PGP key download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:wheezy
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
 RUN echo "deb http://nginx.org/packages/mainline/debian/ wheezy nginx" >> /etc/apt/sources.list
 
 ENV NGINX_VERSION 1.7.12-1~wheezy


### PR DESCRIPTION
The hkp service (port 11371) is likely to be blocked by firewalls.
To enable building of this image in a corporate environment,
http should be used instead.