### PR TITLE
Add AUTOINDEX=ON environment variable to index static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ RUN apt-get update && \
 RUN ln -sf /dev/stdout /var/log/nginx/access.log
 RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
+COPY entry.sh /entry.sh
+
 VOLUME ["/var/cache/nginx"]
 
 EXPOSE 80 443
 
+ENTRYPOINT ["/entry.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ ON = "$AUTOINDEX" ]]; then
+    sed -i -e '/location \// { p; c \
+        autoindex on;
+    }' /etc/nginx/conf.d/default.conf
+fi
+
+exec "$@"


### PR DESCRIPTION
Added an entrypoint that updates the configuration depending on environment variables.

If the environment variable `AUTOINDEX` is set to `ON` this will generate a `autoindex on;` on the default configuration.