### PR TITLE
Added gettext-base package to image in order to make envsubst available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/a
 ENV NGINX_VERSION 1.9.9-1~jessie
 
 RUN apt-get update && \
-    apt-get install -y ca-certificates nginx=${NGINX_VERSION} && \
+    apt-get install -y ca-certificates nginx=${NGINX_VERSION} gettext-base && \
     rm -rf /var/lib/apt/lists/*
 
 # forward request and error logs to docker log collector


### PR DESCRIPTION
nginx do not support using environment variables in config files.

This PR adds ```envsubst``` to the image so it is possible to inject such variables in CMD when starting the container. It only adds about 1Mb to the image so please merge this one....

Here is an example for docker-compose:
```
web:
  image: nginx
  links:
   - phpfpm1:php_fpm
  volumes:
   - ./mysite.template:/etc/nginx/conf.d/mysite.template
  ports:
   - "8080:80"
  environment:
   - NGINX_HOST=foobar.com
   - NGINX_HOST_ALIAS=www.foobar.com
   - NGINX_PORT=80
   - NGINX_BASEDIR=/var/www
   - NGINX_CLIENT_MAX_BODY_SIZE=20m
command: /bin/bash -c "envsubst < /etc/nginx/conf.d/mysite.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
```

The ```mysite.template``` file may then contain variable references like this :
```
    listen       ${NGINX_PORT};
```