### PR TITLE
Fix "gpg" usage to stop relying on deprecated and insecure behavior

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.3
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -64,14 +64,15 @@ RUN \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
-	&& gpg --verify nginx.tar.gz.asc \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
+	&& gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
+	&& rm -r "$GNUPGHOME" nginx.tar.gz.asc \
 	&& mkdir -p /usr/src \
 	&& tar -zxC /usr/src -f nginx.tar.gz \
-	&& rm nginx.tar.gz* \
-	&& rm -r /root/.gnupg \
+	&& rm nginx.tar.gz \
 	&& cd /usr/src/nginx-$NGINX_VERSION \
 	&& ./configure $CONFIG --with-debug \
 	&& make \
@@ -98,7 +99,7 @@ RUN \
 	)" \
 	&& apk add --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/nginx-* \
+	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.3
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -53,14 +53,15 @@ RUN \
 		linux-headers \
 		curl \
 		gnupg \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
-	&& gpg --verify nginx.tar.gz.asc \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEYS" \
+	&& gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
+	&& rm -r "$GNUPGHOME" nginx.tar.gz.asc \
 	&& mkdir -p /usr/src \
 	&& tar -zxC /usr/src -f nginx.tar.gz \
-	&& rm nginx.tar.gz* \
-    && rm -r /root/.gnupg \
+	&& rm nginx.tar.gz \
 	&& cd /usr/src/nginx-$NGINX_VERSION \
 	&& ./configure $CONFIG --with-debug \
 	&& make \
@@ -79,7 +80,7 @@ RUN \
 	)" \
 	&& apk add --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
-	&& rm -rf /usr/src/nginx-* \
+	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \


### PR DESCRIPTION
See also docker-library/official-images#1420.

I didn't think this was urgent enough to force you to round-trip on it again for getting https://github.com/docker-library/official-images/pull/1462 through, but wanted to get it on your radar for the next update to the image. :smile:

I also swapped `alpine` to use `:3.3` explicitly so that we don't run into any unexpected problems (for example, if 3.4 were to come out with a new version of gcc and NGINX fails to compile for whatever reason -- just to be on the safer side). :+1: