### PR TITLE
Move CONFIG/GPG_KEYS out of image ENV vars

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -4,53 +4,51 @@ MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 
 ENV NGINX_VERSION 1.11.1
 
-ENV GPG_KEYS B0F4253373F8F6F510D42178520A9993A1C052F8
-ENV CONFIG "\
-	--prefix=/etc/nginx \
-	--sbin-path=/usr/sbin/nginx \
-	--modules-path=/usr/lib/nginx/modules \
-	--conf-path=/etc/nginx/nginx.conf \
-	--error-log-path=/var/log/nginx/error.log \
-	--http-log-path=/var/log/nginx/access.log \
-	--pid-path=/var/run/nginx.pid \
-	--lock-path=/var/run/nginx.lock \
-	--http-client-body-temp-path=/var/cache/nginx/client_temp \
-	--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-	--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-	--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-	--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-	--user=nginx \
-	--group=nginx \
-	--with-http_ssl_module \
-	--with-http_realip_module \
-	--with-http_addition_module \
-	--with-http_sub_module \
-	--with-http_dav_module \
-	--with-http_flv_module \
-	--with-http_mp4_module \
-	--with-http_gunzip_module \
-	--with-http_gzip_static_module \
-	--with-http_random_index_module \
-	--with-http_secure_link_module \
-	--with-http_stub_status_module \
-	--with-http_auth_request_module \
-	--with-http_xslt_module=dynamic \
-	--with-http_image_filter_module=dynamic \
-	--with-http_geoip_module=dynamic \
-	--with-http_perl_module=dynamic \
-	--with-threads \
-	--with-stream \
-	--with-stream_ssl_module \
-	--with-http_slice_module \
-	--with-mail \
-	--with-mail_ssl_module \
-	--with-file-aio \
-	--with-http_v2_module \
-	--with-ipv6 \
-	"
-
-RUN \
-	addgroup -S nginx \
+RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+	&& CONFIG="\
+		--prefix=/etc/nginx \
+		--sbin-path=/usr/sbin/nginx \
+		--modules-path=/usr/lib/nginx/modules \
+		--conf-path=/etc/nginx/nginx.conf \
+		--error-log-path=/var/log/nginx/error.log \
+		--http-log-path=/var/log/nginx/access.log \
+		--pid-path=/var/run/nginx.pid \
+		--lock-path=/var/run/nginx.lock \
+		--http-client-body-temp-path=/var/cache/nginx/client_temp \
+		--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+		--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+		--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+		--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+		--user=nginx \
+		--group=nginx \
+		--with-http_ssl_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_stub_status_module \
+		--with-http_auth_request_module \
+		--with-http_xslt_module=dynamic \
+		--with-http_image_filter_module=dynamic \
+		--with-http_geoip_module=dynamic \
+		--with-http_perl_module=dynamic \
+		--with-threads \
+		--with-stream \
+		--with-stream_ssl_module \
+		--with-http_slice_module \
+		--with-mail \
+		--with-mail_ssl_module \
+		--with-file-aio \
+		--with-http_v2_module \
+		--with-ipv6 \
+	" \
+	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -4,53 +4,51 @@ MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 
 ENV NGINX_VERSION 1.10.1
 
-ENV GPG_KEYS B0F4253373F8F6F510D42178520A9993A1C052F8
-ENV CONFIG "\
-	--prefix=/etc/nginx \
-	--sbin-path=/usr/sbin/nginx \
-	--modules-path=/usr/lib/nginx/modules \
-	--conf-path=/etc/nginx/nginx.conf \
-	--error-log-path=/var/log/nginx/error.log \
-	--http-log-path=/var/log/nginx/access.log \
-	--pid-path=/var/run/nginx.pid \
-	--lock-path=/var/run/nginx.lock \
-	--http-client-body-temp-path=/var/cache/nginx/client_temp \
-	--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-	--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-	--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-	--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-	--user=nginx \
-	--group=nginx \
-	--with-http_ssl_module \
-	--with-http_realip_module \
-	--with-http_addition_module \
-	--with-http_sub_module \
-	--with-http_dav_module \
-	--with-http_flv_module \
-	--with-http_mp4_module \
-	--with-http_gunzip_module \
-	--with-http_gzip_static_module \
-	--with-http_random_index_module \
-	--with-http_secure_link_module \
-	--with-http_stub_status_module \
-	--with-http_auth_request_module \
-	--with-http_xslt_module=dynamic \
-	--with-http_image_filter_module=dynamic \
-	--with-http_geoip_module=dynamic \
-	--with-http_perl_module=dynamic \
-	--with-threads \
-	--with-stream \
-	--with-stream_ssl_module \
-	--with-http_slice_module \
-	--with-mail \
-	--with-mail_ssl_module \
-	--with-file-aio \
-	--with-http_v2_module \
-	--with-ipv6 \
-	"
-
-RUN \
-	addgroup -S nginx \
+RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+	&& CONFIG="\
+		--prefix=/etc/nginx \
+		--sbin-path=/usr/sbin/nginx \
+		--modules-path=/usr/lib/nginx/modules \
+		--conf-path=/etc/nginx/nginx.conf \
+		--error-log-path=/var/log/nginx/error.log \
+		--http-log-path=/var/log/nginx/access.log \
+		--pid-path=/var/run/nginx.pid \
+		--lock-path=/var/run/nginx.lock \
+		--http-client-body-temp-path=/var/cache/nginx/client_temp \
+		--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+		--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+		--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+		--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+		--user=nginx \
+		--group=nginx \
+		--with-http_ssl_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_stub_status_module \
+		--with-http_auth_request_module \
+		--with-http_xslt_module=dynamic \
+		--with-http_image_filter_module=dynamic \
+		--with-http_geoip_module=dynamic \
+		--with-http_perl_module=dynamic \
+		--with-threads \
+		--with-stream \
+		--with-stream_ssl_module \
+		--with-http_slice_module \
+		--with-mail \
+		--with-mail_ssl_module \
+		--with-file-aio \
+		--with-http_v2_module \
+		--with-ipv6 \
+	" \
+	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \


### PR DESCRIPTION
There's no reason for these to exist as environment variables, and
CONFIG is pretty clunky and useless outside of build time.

I'd argue that if someone wanted to be able to inspect this information,
it could be retrieved from `nginx -V`.

Another point is that these don't exist for the `debian:jessie` based
images either.