### PR TITLE
add parallel process make with "-j" param

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -75,7 +75,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& rm nginx.tar.gz \
 	&& cd /usr/src/nginx-$NGINX_VERSION \
 	&& ./configure $CONFIG --with-debug \
-	&& make \
+	&& make -j$(($(cat /proc/cpuinfo | awk '/^processor/{print $3}' | tail -1) + 1)) \
 	&& mv objs/nginx objs/nginx-debug \
 	&& mv objs/ngx_http_xslt_filter_module.so objs/ngx_http_xslt_filter_module-debug.so \
 	&& mv objs/ngx_http_image_filter_module.so objs/ngx_http_image_filter_module-debug.so \


### PR DESCRIPTION
For better performance when building can add the "-j" param using the "(number of processors) + 1" formula