### PR TITLE
Add script to generate stackbrew library for upstream

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -eu
+
+declare -A aliases
+aliases=(
+	[mainline]='1 1.11 latest'
+	[stable]='1.10'
+)
+
+self="$(basename "$BASH_SOURCE")"
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+base=jessie
+
+versions=( */ )
+versions=( "${versions[@]%/}" )
+
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir"
+		fileCommit \
+			Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++) {
+						print $i
+					}
+				}
+			')
+	)
+}
+
+cat <<-EOH
+# this file is generated via https://github.com/nginxinc/docker-nginx/blob/$(fileCommit "$self")/$self
+
+Maintainers: Docker Maintainers <docker-maint@nginx.com>
+GitRepo: https://github.com/nginxinc/docker-nginx.git
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+for version in "${versions[@]}"; do
+	commit="$(dirCommit "$version/$base")"
+
+	fullVersion="$(git show "$commit":"$version/$base/Dockerfile" | awk '$1 == "ENV" && $2 == "NGINX_VERSION" { print $3; exit }')"
+	fullVersion="${fullVersion%[.-]*}"
+
+	versionAliases=( $fullVersion )
+	if [ "$version" != "$fullVersion" ]; then
+		versionAliases+=( $version )
+	fi
+	versionAliases+=( ${aliases[$version]:-} )
+
+	echo
+	cat <<-EOE
+		Tags: $(join ', ' "${versionAliases[@]}")
+		GitCommit: $commit
+		Directory: $version/$base
+	EOE
+
+	for variant in alpine; do
+		commit="$(dirCommit "$version/$variant")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
+		echo
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
+	done
+done


### PR DESCRIPTION
This will be needed to better facilitate updating nginx in the official registry.  See #97

/cc @tianon @yosifkit

Running this yields:

```
# this file is generated via https://github.com/nginxinc/docker-nginx/blob/1f9792d654aae454cd7d56de0e3097385f24f78c/generate-stackbrew-library.sh

Maintainers: Docker Maintainers <docker-maint@nginx.com>
GitRepo: https://github.com/nginxinc/docker-nginx.git

Tags: 1.11.2, mainline, 1, 1.11, latest
GitCommit: 024c1c8ddc84e351692b37a7656455dcf2707315
Directory: mainline/jessie

Tags: 1.11.2-alpine, mainline-alpine, 1-alpine, 1.11-alpine, alpine
GitCommit: 43c112100750cbd1e9f2160324c64988e7920ac9
Directory: mainline/alpine

Tags: 1.10.1, stable, 1.10
GitCommit: 11fc019b2be3ad51ba5d097b1857a099c4056213
Directory: stable/jessie

Tags: 1.10.1-alpine, stable-alpine, 1.10-alpine
GitCommit: 43c112100750cbd1e9f2160324c64988e7920ac9
Directory: stable/alpine
```