### PR TITLE
Bring http2 support back to chrome.

### DIFF
--- a/mainline/xenial/Dockerfile
+++ b/mainline/xenial/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:16.04
+
+MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
+
+RUN \
+  apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62\
+  && echo "deb http://nginx.org/packages/mainline/ubuntu/ xenial nginx\ndeb-src http://nginx.org/packages/mainline/ubuntu/ xenial nginx" >> /etc/apt/sources.list\
+  && apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+  openssl \
+  nginx \
+  ca-certificates \
+  nginx-module-xslt \
+  nginx-module-geoip \
+  nginx-module-image-filter \
+  nginx-module-perl \
+  nginx-module-njs \
+  gettext-base \
+	&& rm -rf /var/lib/apt/lists/*
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
How about adding an official image for ubuntu/xenial?

Then we could get http2 support in chrome without building our own custom docker images?

This PR is in response to https://github.com/nginxinc/docker-nginx/issues/76
