### PR TITLE
do not expose port 443 because it is not used by default

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -130,6 +130,6 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80 443
+EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/jessie/Dockerfile
+++ b/mainline/jessie/Dockerfile
@@ -22,6 +22,6 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 
-EXPOSE 80 443
+EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -125,6 +125,6 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80 443
+EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/jessie/Dockerfile
+++ b/stable/jessie/Dockerfile
@@ -22,6 +22,6 @@ RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC64107
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
 
-EXPOSE 80 443
+EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The default nginx configuration does not configure nginx to be
listening on port 443.

However, the Dockerfile exposes this port, which has some implications;

- users get the expectation that nginx is listening on port 443, but
  when publishing the port discover that no connection can be
  established.
- when using `-P` / `--publish-all`, docker will publish port 443 (using
  random port mapping)
- some proxies use "expose" to detect which ports are provided by a
  container and make configuration decisions based on that information,
  again leading to port 443 being mapped, but not functional.

This change removes port 443 from the Dockerfile.

Removing this port can be a breaking change, so should be documented
(i.e., users should now add `EXPOSE 443` in their Dockerfile if they
extend the nginx image, or use `--expose 443` when running the image.

/cc @tianon to check if this matches the "best practices" for official images