### PR TITLE
Use Entrypoint Instead of Cmd for Nginx Container

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -132,4 +132,4 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/mainline/jessie/Dockerfile
+++ b/mainline/jessie/Dockerfile
@@ -24,4 +24,4 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -127,4 +127,4 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/stable/jessie/Dockerfile
+++ b/stable/jessie/Dockerfile
@@ -24,4 +24,4 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
After this change I'm be able to start nginx like this:

docker run nginx:1.10 -c /mypath/nginx.conf

Currently i'd need to do:

docker run nginx:1.10 nginx -c /mypath/nginx.conf