### PR TITLE
Specify nginx version for all packages

### DIFF
--- a/mainline/jessie/Dockerfile
+++ b/mainline/jessie/Dockerfile
@@ -24,11 +24,11 @@ RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/a
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 						ca-certificates \
 						nginx=${NGINX_VERSION} \
-						nginx-module-xslt \
-						nginx-module-geoip \
-						nginx-module-image-filter \
-						nginx-module-perl \
-						nginx-module-njs \
+						nginx-module-xslt=${NGINX_VERSION} \
+						nginx-module-geoip=${NGINX_VERSION} \
+						nginx-module-image-filter=${NGINX_VERSION} \
+						nginx-module-perl=${NGINX_VERSION} \
+						nginx-module-njs=${NGINX_VERSION} \
 						gettext-base \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/stable/jessie/Dockerfile
+++ b/stable/jessie/Dockerfile
@@ -24,11 +24,11 @@ RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/source
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 						ca-certificates \
 						nginx=${NGINX_VERSION} \
-						nginx-module-xslt \
-						nginx-module-geoip \
-						nginx-module-image-filter \
-						nginx-module-perl \
-						nginx-module-njs \
+						nginx-module-xslt=${NGINX_VERSION} \
+						nginx-module-geoip=${NGINX_VERSION} \
+						nginx-module-image-filter=${NGINX_VERSION} \
+						nginx-module-perl=${NGINX_VERSION} \
+						nginx-module-njs=${NGINX_VERSION} \
 						gettext-base \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
To avoid unmet dependencies when building the image after nginx got updated, but the Dockerfile hasn't yet