### PR TITLE
Use alpine:3.6 base image

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 MAINTAINER NGINX Docker Maintainers "docker-maint@nginx.com"
 


### PR DESCRIPTION
The alpine:3.5 base image has several known vulnerabilities in zlib, with "critical" or "major" severity.

See

- https://hub.docker.com/r/library/alpine/tags/3.5/
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9841
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9843
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9842
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9840

alpine:3.6 uses a newer zlib version and has no known vulnerabilities. See

https://hub.docker.com/r/library/alpine/tags/3.6/