### PR TITLE
Upd: Boost worker_connections from 1024 to 10240.

### DIFF
--- a/mainline/alpine-perl/nginx.conf
+++ b/mainline/alpine-perl/nginx.conf
@@ -7,7 +7,7 @@ pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  10240;
 }
 
 

--- a/mainline/alpine/nginx.conf
+++ b/mainline/alpine/nginx.conf
@@ -7,7 +7,7 @@ pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  10240;
 }
 
 

--- a/stable/alpine-perl/nginx.conf
+++ b/stable/alpine-perl/nginx.conf
@@ -7,7 +7,7 @@ pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  10240;
 }
 
 

--- a/stable/alpine/nginx.conf
+++ b/stable/alpine/nginx.conf
@@ -7,7 +7,7 @@ pid        /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  10240;
 }
 
 


### PR DESCRIPTION
> It's very common to have thousands of clients, especially for a public website. I stopped counting the amount of websites I've seen went down because of the low defaults.

[source](https://serverfault.com/questions/787919/optimal-value-for-nginx-worker-connections)

