### PR TITLE
WIP: add envsubst wrapper

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -138,6 +138,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
+COPY ../../nginx-envsubst.sh /usr/bin/nginx-envsubst
 
 EXPOSE 80
 

--- a/nginx-envsubst.sh
+++ b/nginx-envsubst.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec envsubst "$(printf '${%s} ' $(env | cut -d= -f1))"


### PR DESCRIPTION
the wrapper replaces only known env variables, leaves unknown ones
intact

this addresses problem where unknown variables are replaced empty:
https://github.com/docker-library/docs/issues/496

my change was inspired from this comment:
https://github.com/docker-library/docs/issues/496#issuecomment-313065989

but uses more standard solution instead bash specific `compgen`