### PR TITLE
Added brotli module install for alpine editions

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -50,7 +50,15 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-compat \
 		--with-file-aio \
 		--with-http_v2_module \
+		--add-module=/usr/local/src/ngx_brotli \
 	" \
+	&& mkdir -p /usr/local/src/ \
+	&& cd /usr/local/src \
+	&& apk add --no-cache git \
+	&& git clone https://github.com/google/ngx_brotli.git \
+	&& cd ngx_brotli \
+	&& git submodule update --init --recursive \
+	&& cd / \
 	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
@@ -131,6 +139,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
 	&& apk del .gettext \
+	&& apk del git \
+	&& rm -r /usr/local/src/ngx_brotli \
 	&& mv /tmp/envsubst /usr/local/bin/ \
 	\
 	# Bring in tzdata so users could set the timezones through the environment

--- a/mainline/alpine-perl/nginx.vh.default.conf
+++ b/mainline/alpine-perl/nginx.vh.default.conf
@@ -2,6 +2,19 @@ server {
     listen       80;
     server_name  localhost;
 
+    # enable compression for new and old browsers
+    #
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/x-javascript application/javascript application/json;
+    gzip_vary on;
+    gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+    brotli on;
+    brotli_comp_level 4;
+    brotli_types text/plain text/css application/x-javascript application/javascript application/json;
+    brotli_static on;
+
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -49,7 +49,15 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-compat \
 		--with-file-aio \
 		--with-http_v2_module \
+		--add-module=/usr/local/src/ngx_brotli \
 	" \
+	&& mkdir -p /usr/local/src/ \
+	&& cd /usr/local/src \
+	&& apk add --no-cache git \
+	&& git clone https://github.com/google/ngx_brotli.git \
+	&& cd ngx_brotli \
+	&& git submodule update --init --recursive \
+	&& cd / \
 	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
@@ -126,6 +134,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
 	&& apk del .gettext \
+	&& apk del git \
+	&& rm -r /usr/local/src/ngx_brotli \
 	&& mv /tmp/envsubst /usr/local/bin/ \
 	\
 	# Bring in tzdata so users could set the timezones through the environment

--- a/mainline/alpine/nginx.vh.default.conf
+++ b/mainline/alpine/nginx.vh.default.conf
@@ -2,6 +2,19 @@ server {
     listen       80;
     server_name  localhost;
 
+    # enable compression for new and old browsers
+    #
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/x-javascript application/javascript application/json;
+    gzip_vary on;
+    gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+    brotli on;
+    brotli_comp_level 4;
+    brotli_types text/plain text/css application/x-javascript application/javascript application/json;
+    brotli_static on;
+
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -50,7 +50,15 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-compat \
 		--with-file-aio \
 		--with-http_v2_module \
+		--add-module=/usr/local/src/ngx_brotli \
 	" \
+	&& mkdir -p /usr/local/src/ \
+	&& cd /usr/local/src \
+	&& apk add --no-cache git \
+	&& git clone https://github.com/google/ngx_brotli.git \
+	&& cd ngx_brotli \
+	&& git submodule update --init --recursive \
+	&& cd / \
 	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
@@ -131,6 +139,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
 	&& apk del .gettext \
+	&& apk del git \
+	&& rm -r /usr/local/src/ngx_brotli \
 	&& mv /tmp/envsubst /usr/local/bin/ \
 	\
 	# Bring in tzdata so users could set the timezones through the environment

--- a/stable/alpine-perl/nginx.vh.default.conf
+++ b/stable/alpine-perl/nginx.vh.default.conf
@@ -2,6 +2,19 @@ server {
     listen       80;
     server_name  localhost;
 
+    # enable compression for new and old browsers
+    #
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/x-javascript application/javascript application/json;
+    gzip_vary on;
+    gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+    brotli on;
+    brotli_comp_level 4;
+    brotli_types text/plain text/css application/x-javascript application/javascript application/json;
+    brotli_static on;
+
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -49,7 +49,15 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-compat \
 		--with-file-aio \
 		--with-http_v2_module \
+		--add-module=/usr/local/src/ngx_brotli \
 	" \
+	&& mkdir -p /usr/local/src/ \
+	&& cd /usr/local/src \
+	&& apk add --no-cache git \
+	&& git clone https://github.com/google/ngx_brotli.git \
+	&& cd ngx_brotli \
+	&& git submodule update --init --recursive \
+	&& cd / \
 	&& addgroup -S nginx \
 	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
@@ -126,6 +134,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
 	&& apk del .build-deps \
 	&& apk del .gettext \
+	&& apk del git \
+	&& rm -r /usr/local/src/ngx_brotli \
 	&& mv /tmp/envsubst /usr/local/bin/ \
 	\
 	# Bring in tzdata so users could set the timezones through the environment

--- a/stable/alpine/nginx.vh.default.conf
+++ b/stable/alpine/nginx.vh.default.conf
@@ -2,6 +2,19 @@ server {
     listen       80;
     server_name  localhost;
 
+    # enable compression for new and old browsers
+    #
+    gzip on;
+    gzip_proxied any;
+    gzip_types text/plain text/css application/x-javascript application/javascript application/json;
+    gzip_vary on;
+    gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+
+    brotli on;
+    brotli_comp_level 4;
+    brotli_types text/plain text/css application/x-javascript application/javascript application/json;
+    brotli_static on;
+
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 


### PR DESCRIPTION
This add Google's Brotli compression module for nginx. Brotli is faster and more effective than gzip on default compression level and for static files it results with around 20% smaller sizes than gzip.

It's supported by all major browsers (except IE, which is not updated anymore, but Chrome, Firefox, Edge, Safari, they all support Brotli) and of course nginx will use it only for browsers that supports it.

It's around for few years and Facebook & Google (as example of the biggest ones) are serving their text-based assets using Brotli. Having this in most popular docker image of nginx would definitely help spreading it's usage.

Debian images are to-be-done. I did it mostly for myself and wanted to see if this even got accepted. I'll add it for Debian-based images as well if you're going to accept this.