### PR TITLE
Run envsubst automatically during starting container

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -110,6 +110,10 @@ RUN set -x \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/mainline/alpine/entrypoint.sh
+++ b/mainline/alpine/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -ex
+
+main() {
+  local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
+  local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
+  local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
+
+  local template defined_envs relative_path output_path subdir
+  defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
+  [ -d "$template_dir" ] || return 0
+  [ -w "$output_dir" ] || return 0
+  for template in $(find "$template_dir" -follow -name "*$suffix"); do
+    relative_path="${template#$template_dir/}"
+    output_path="$output_dir/${relative_path%$suffix}"
+    subdir=$(dirname "$relative_path")
+    # create a subdirectory where the template file exists
+    mkdir -p "$output_dir/$subdir"
+    envsubst "$defined_envs" < "$template" > "$output_path"
+  done
+}
+
+main
+
+exec "$@"

--- a/mainline/alpine/entrypoint.sh
+++ b/mainline/alpine/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-main() {
+auto_envsubst() {
   local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
@@ -10,7 +10,10 @@ main() {
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
   [ -d "$template_dir" ] || return 0
-  [ -w "$output_dir" ] || return 0
+  if [ ! -w "$output_dir" ]; then
+    echo "ERROR: $template_dir exists, but $output_dir is not writable. exiting..." 1>&2
+    return 1
+  fi
   for template in $(find "$template_dir" -follow -name "*$suffix"); do
     relative_path="${template#$template_dir/}"
     output_path="$output_dir/${relative_path%$suffix}"
@@ -21,6 +24,6 @@ main() {
   done
 }
 
-main
+auto_envsubst
 
 exec "$@"


### PR DESCRIPTION
This PR adds the feature to automatically run envsubst for files with the suffix `.conf.template` on `/etc/nginx`, and output to `.conf` file.
If there is no file with the suffix `.conf.template`, the added script does nothing.

This PR was made with reference to PR #217. 
Thanks @glensc!