### PR TITLE
downgrade to gnupg1

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -62,7 +62,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg \
+		gnupg1 \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -61,7 +61,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg \
+		gnupg1 \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -62,7 +62,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg \
+		gnupg1 \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -61,7 +61,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		zlib-dev \
 		linux-headers \
 		curl \
-		gnupg \
+		gnupg1 \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \


### PR DESCRIPTION
The build sometimes fails to remove the `S.gpg-agent.extra` unix domain socket
when it deletes the temporary GNUPGHOME directory after running gpg commands.

    rm: can't remove '/tmp/tmp.hBDCKF/S.gpg-agent.extra': No such file or directory

The previous gpg --recv-keys command starts the gpg-agent. The gpg-agent
connects to the following sockets and does not terminate on its own.

    / # netstat -x -a -p
    Active UNIX domain sockets (servers and established)
    Proto RefCnt Flags       Type       State         I-Node PID/Program name    Path
    unix  2      [ ACC ]     STREAM     LISTENING     8627378 17/dirmngr          /root/.gnupg/S.dirmngr
    unix  2      [ ACC ]     STREAM     LISTENING     8625135 21/gpg-agent        /root/.gnupg/S.gpg-agent
    unix  2      [ ACC ]     STREAM     LISTENING     8625136 21/gpg-agent        /root/.gnupg/S.gpg-agent.extra
    unix  2      [ ACC ]     STREAM     LISTENING     8625137 21/gpg-agent        /root/.gnupg/S.gpg-agent.browser
    unix  2      [ ACC ]     STREAM     LISTENING     8625138 21/gpg-agent        /root/.gnupg/S.gpg-agent.ssh

If one of the sockets is removed, then the agent terminates and removes the
other sockets as well. This causes a race condition between `rm -rf $GNUPGHOME`
and gpg-agent. If gpg-agent manages to remove the sockets first, then `rm`
fails while trying to remove the same socket.

Move to gnupg1 in alpine just like we do for stretch. Gnupg version 1
does not launch a GPG agent. It is not possible to disable gpg-agent in
gnupg version 2.