### PR TITLE
Use stable gid/uid

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -4,6 +4,11 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.15.5
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
+
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -51,8 +56,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& addgroup -S --gid $NGINX_GID nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -4,11 +4,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.15.5
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
-
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -56,8 +51,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S --gid $NGINX_GID nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -141,6 +136,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# Bring in tzdata so users could set the timezones through the environment
 	# variables
 	&& apk add --no-cache tzdata \
+	# Install groupmod & usermod so users could update gid/uid through environment
+    # variables (see entrypoint).
+    && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
@@ -152,5 +150,8 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -137,7 +137,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# variables
 	&& apk add --no-cache tzdata \
 	# Install groupmod & usermod so users could update gid/uid through environment
-    # variables (see entrypoint).
+	# variables (see entrypoint).
     && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector

--- a/mainline/alpine-perl/entrypoint.sh
+++ b/mainline/alpine-perl/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -4,6 +4,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.15.5
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -50,8 +54,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& addgroup -S --gid $NGINX_GID nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -4,10 +4,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.15.5
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -54,8 +50,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S --gid $NGINX_GID nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -135,6 +131,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# Bring in tzdata so users could set the timezones through the environment
 	# variables
 	&& apk add --no-cache tzdata \
+	# Install groupmod & usermod so users could update gid/uid through environment
+	# variables (see entrypoint).
+	&& apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
@@ -146,5 +145,8 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/alpine/entrypoint.sh
+++ b/mainline/alpine/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/mainline/stretch-perl/Dockerfile
+++ b/mainline/stretch-perl/Dockerfile
@@ -5,6 +5,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.15.5-1~stretch
 ENV NJS_VERSION   1.15.5.0.2.4-1~stretch
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -88,6 +92,9 @@ RUN set -x \
 		apt-get purge -y --auto-remove \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
+
+RUN groupmod -g $NGINX_GID nginx \
+    && usermod -u $NGINX_UID nginx
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/mainline/stretch-perl/Dockerfile
+++ b/mainline/stretch-perl/Dockerfile
@@ -5,10 +5,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.15.5-1~stretch
 ENV NJS_VERSION   1.15.5.0.2.4-1~stretch
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -93,9 +89,6 @@ RUN set -x \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
 
-RUN groupmod -g $NGINX_GID nginx \
-    && usermod -u $NGINX_UID nginx
-
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
@@ -103,5 +96,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch-perl/entrypoint.sh
+++ b/mainline/stretch-perl/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/mainline/stretch/Dockerfile
+++ b/mainline/stretch/Dockerfile
@@ -5,6 +5,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.15.5-1~stretch
 ENV NJS_VERSION   1.15.5.0.2.4-1~stretch
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -87,6 +91,9 @@ RUN set -x \
 		apt-get purge -y --auto-remove \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
+
+RUN groupmod -g $NGINX_GID nginx \
+    && usermod -u $NGINX_UID nginx
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/mainline/stretch/Dockerfile
+++ b/mainline/stretch/Dockerfile
@@ -5,10 +5,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.15.5-1~stretch
 ENV NJS_VERSION   1.15.5.0.2.4-1~stretch
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -92,9 +88,6 @@ RUN set -x \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
 
-RUN groupmod -g $NGINX_GID nginx \
-    && usermod -u $NGINX_UID nginx
-
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
@@ -102,5 +95,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/stretch/entrypoint.sh
+++ b/mainline/stretch/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -137,7 +137,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# variables
 	&& apk add --no-cache tzdata \
 	# Install groupmod & usermod so users could update gid/uid through environment
-    # variables (see entrypoint).
+	# variables (see entrypoint).
     && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -4,10 +4,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.14.0
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -55,8 +51,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S --gid $NGINX_UID nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -140,6 +136,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# Bring in tzdata so users could set the timezones through the environment
 	# variables
 	&& apk add --no-cache tzdata \
+	# Install groupmod & usermod so users could update gid/uid through environment
+    # variables (see entrypoint).
+    && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
@@ -151,5 +150,8 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -4,6 +4,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.14.0
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -51,8 +55,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& addgroup -S --gid $NGINX_UID nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \

--- a/stable/alpine-perl/entrypoint.sh
+++ b/stable/alpine-perl/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -4,6 +4,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.14.0
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -50,8 +54,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& addgroup -S --gid $NGINX_UID nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -4,10 +4,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.14.0
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\
 		--prefix=/etc/nginx \
@@ -54,8 +50,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-file-aio \
 		--with-http_v2_module \
 	" \
-	&& addgroup -S --gid $NGINX_UID nginx \
-	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid $NGINX_UID nginx \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
 	&& apk add --no-cache --virtual .build-deps \
 		gcc \
 		libc-dev \
@@ -135,6 +131,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# Bring in tzdata so users could set the timezones through the environment
 	# variables
 	&& apk add --no-cache tzdata \
+	# Install groupmod & usermod so users could update gid/uid through environment
+    # variables (see entrypoint).
+    && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
@@ -146,5 +145,8 @@ COPY nginx.vh.default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -132,7 +132,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	# variables
 	&& apk add --no-cache tzdata \
 	# Install groupmod & usermod so users could update gid/uid through environment
-    # variables (see entrypoint).
+	# variables (see entrypoint).
     && apk add --no-cache shadow \
 	\
 	# forward request and error logs to docker log collector

--- a/stable/alpine/entrypoint.sh
+++ b/stable/alpine/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/stable/stretch-perl/Dockerfile
+++ b/stable/stretch-perl/Dockerfile
@@ -5,6 +5,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.14.0-1~stretch
 ENV NJS_VERSION   1.14.0.0.2.0-1~stretch
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -88,6 +92,9 @@ RUN set -x \
 		apt-get purge -y --auto-remove \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
+
+RUN groupmod -g $NGINX_GID nginx \
+    && usermod -u $NGINX_UID nginx
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/stable/stretch-perl/Dockerfile
+++ b/stable/stretch-perl/Dockerfile
@@ -5,10 +5,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.14.0-1~stretch
 ENV NJS_VERSION   1.14.0.0.2.0-1~stretch
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -93,9 +89,6 @@ RUN set -x \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
 
-RUN groupmod -g $NGINX_GID nginx \
-    && usermod -u $NGINX_UID nginx
-
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
@@ -103,5 +96,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/stretch-perl/entrypoint.sh
+++ b/stable/stretch-perl/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"

--- a/stable/stretch/Dockerfile
+++ b/stable/stretch/Dockerfile
@@ -5,10 +5,6 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.14.0-1~stretch
 ENV NJS_VERSION   1.14.0.0.2.0-1~stretch
 
-# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
-ENV NGINX_GID 8123
-ENV NGINX_UID 8123
-
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -92,9 +88,6 @@ RUN set -x \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
 
-RUN groupmod -g $NGINX_GID nginx \
-    && usermod -u $NGINX_UID nginx
-
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
@@ -102,5 +95,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 EXPOSE 80
 
 STOPSIGNAL SIGTERM
+
+COPY entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/stretch/Dockerfile
+++ b/stable/stretch/Dockerfile
@@ -5,6 +5,10 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 ENV NGINX_VERSION 1.14.0-1~stretch
 ENV NJS_VERSION   1.14.0.0.2.0-1~stretch
 
+# Stable gid/uid allows you pre-configure disk volumes with proper ownership (`chown`) for use by Nginx.
+ENV NGINX_GID 8123
+ENV NGINX_UID 8123
+
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
@@ -87,6 +91,9 @@ RUN set -x \
 		apt-get purge -y --auto-remove \
 		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
 	fi
+
+RUN groupmod -g $NGINX_GID nginx \
+    && usermod -u $NGINX_UID nginx
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/stable/stretch/entrypoint.sh
+++ b/stable/stretch/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# This entrypoint allows Nginx gid/uid customization.
+# By default Nginx will use automatically generated gid/uid.
+# User can override both gid and uid by passing environment variables to the container.
+# Set "NGINX_GID" to change Nginx gid (must not be equal to non-nginx gid in the image).
+# Set "NGINX_UID" to change Nginx uid (must not be equal to non-nginx uid in the image).
+# Normally, gid and uid are the same number.
+# Stable gid/uid allows user pre-configure disk volumes with proper file ownership.
+# Note: changing gid/uid doesn't change ownership of already created files with previous gid/uid values (but there shouldn't be any).
+
+if [ -z "$NGINX_GID" ]; then
+    nginx_gid="$(id -g nginx)"
+    echo "Using default gid for Nginx: $nginx_gid. Note: default gid is not guaranteed to be stable across image updates. You can set NGINX_GID environment variable to customize Nginx gid."
+else
+    groupmod -g "$NGINX_GID" nginx
+    echo "Nginx gid has been changed to $NGINX_GID."
+fi
+
+if [ -z "$NGINX_UID" ]; then
+    nginx_uid="$(id -u nginx)"
+    echo "Using default uid for Nginx: $nginx_uid. Note: default uid is not guaranteed to be stable across image updates. You can set NGINX_UID environment variable to customize Nginx uid."
+else
+    usermod -u "$NGINX_UID" nginx
+    echo "Nginx uid has been changed to $NGINX_UID."
+fi
+
+exec "$@"


### PR DESCRIPTION
Fixes #113, specifically https://github.com/nginxinc/docker-nginx/issues/113#issuecomment-237482535.

### Motivation

Nginx proxy_cache and other features need read/write access to the disk. Disk normally is mounted upfront and gets fs mounted and owned by `root` who runs docker/etc daemon.

For Nginx to be able to read/write mounted disk, files **must** have proper access permissions.

One of the best ways to do it is to assign ownership to the proper user/group upfront. 

Unfortunately, Nginx atm doesn't use fixed gid/uid (they're fixed within Docker image version, but can be changed on next image rebuild due to changes in Alpine) and this complicates setup a lot, especially in environments like Kubernetes where you can't control external gid/uid or pass it to the container at startup.

This PR adds fixed high-order gid/uid values to address that.

Similar change in couchdb for reference: https://github.com/apache/couchdb-docker/pull/64/files

With this change it'll be possible to mount disk like this (k8s):

```yaml
initContainers:
- name: "grant-permissions"
  image: "busybox:1.26.2"
  env:
  - name: NGINX_GID
    value: 8123
  - name: NGINX_UID
    value: 8123
  command:
  - 'sh'
  - '-c'
  - 'chown -R ${NGINX_UID}:${NGINX_GID} /opt/nginx-cache'
  volumeMounts:
  - mountPath: "/opt/nginx-cache"
    name: nginx-cache
containers:
- name: nginx
  image: nginx:1.15.4-alpine
  volumeMounts:
  - name: nginx-cache
    mountPath: /opt/nginx-cache
```

---

If this change gets approved in general, I'll update the remaining `Dockerfile`s in the repo in this PR