### PR TITLE
Fix #286: added nginx-dav-ext-module

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -26,6 +26,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		--with-http_addition_module \
 		--with-http_sub_module \
 		--with-http_dav_module \
+		--add-module=/usr/src/nginx-dav-ext-module \
 		--with-http_flv_module \
 		--with-http_mp4_module \
 		--with-http_gunzip_module \
@@ -65,6 +66,9 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		libxslt-dev \
 		gd-dev \
 		geoip-dev \
+		git \
+		expat-dev \
+	&& git clone https://github.com/arut/nginx-dav-ext-module.git /usr/src/nginx-dav-ext-module \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
@@ -108,7 +112,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
 	&& strip /usr/sbin/nginx* \
 	&& strip /usr/lib/nginx/modules/*.so \
-	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
+	&& rm -rf /usr/src/nginx-$NGINX_VERSION /usr/src/nginx-dav-ext-module \
 	\
 	# Bring in gettext so we can get `envsubst`, then throw
 	# the rest away. To do this, we need to install `gettext`


### PR DESCRIPTION
The Debian based image is compiled with the [nginx-dav-ext module](https://github.com/arut/nginx-dav-ext-module) enabled. The Alpine version version is compiled without this module, which in my view is inconsistent.
This merge request adds the nginx-dav-ext module to the Alpine version.