### PR TITLE
chore: upgrade nginx to 1.16.1

### DIFF
--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.16.1
-ENV NJS_VERSION   0.3.2
+ENV NJS_VERSION   0.3.4
 ENV PKG_RELEASE   1
 
 RUN set -x \

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION 1.16.0
+ENV NGINX_VERSION 1.16.1
 ENV NJS_VERSION   0.3.2
 ENV PKG_RELEASE   1
 

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.16.1
-ENV NJS_VERSION   0.3.2
+ENV NJS_VERSION   0.3.4
 ENV PKG_RELEASE   1
 
 RUN set -x \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION 1.16.0
+ENV NGINX_VERSION 1.16.1
 ENV NJS_VERSION   0.3.2
 ENV PKG_RELEASE   1
 

--- a/stable/buster-perl/Dockerfile
+++ b/stable/buster-perl/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION   1.16.0
+ENV NGINX_VERSION   1.16.1
 ENV NJS_VERSION     0.3.2
 ENV PKG_RELEASE     1~buster
 

--- a/stable/buster-perl/Dockerfile
+++ b/stable/buster-perl/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.16.1
-ENV NJS_VERSION     0.3.2
+ENV NJS_VERSION     0.3.4
 ENV PKG_RELEASE     1~buster
 
 RUN set -x \

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION   1.16.0
+ENV NGINX_VERSION   1.16.1
 ENV NJS_VERSION     0.3.2
 ENV PKG_RELEASE     1~buster
 

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.16.1
-ENV NJS_VERSION     0.3.2
+ENV NJS_VERSION     0.3.4
 ENV PKG_RELEASE     1~buster
 
 RUN set -x \


### PR DESCRIPTION
Hi, here is a PR to upgrade to latest 1.16.x version. Let me now if you would like I reword, squash commits, whatever. Thank you :)

```
Changes with nginx 1.16.1                                        13 Aug 2019

    *) Security: when using HTTP/2 a client might cause excessive memory
       consumption and CPU usage (CVE-2019-9511, CVE-2019-9513,
       CVE-2019-9516).
```