### PR TITLE
chore: upgrade nginx to 1.17.3

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION 1.17.2
+ENV NGINX_VERSION 1.17.3
 ENV NJS_VERSION   0.3.3
 ENV PKG_RELEASE   1
 

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.17.3
-ENV NJS_VERSION   0.3.3
+ENV NJS_VERSION   0.3.4
 ENV PKG_RELEASE   1
 
 RUN set -x \

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION 1.17.2
+ENV NGINX_VERSION 1.17.3
 ENV NJS_VERSION   0.3.3
 ENV PKG_RELEASE   1
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.17.3
-ENV NJS_VERSION   0.3.3
+ENV NJS_VERSION   0.3.4
 ENV PKG_RELEASE   1
 
 RUN set -x \

--- a/mainline/buster-perl/Dockerfile
+++ b/mainline/buster-perl/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.17.3
-ENV NJS_VERSION     0.3.3
+ENV NJS_VERSION     0.3.4
 ENV PKG_RELEASE     1~buster
 
 RUN set -x \

--- a/mainline/buster-perl/Dockerfile
+++ b/mainline/buster-perl/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION   1.17.2
+ENV NGINX_VERSION   1.17.3
 ENV NJS_VERSION     0.3.3
 ENV PKG_RELEASE     1~buster
 

--- a/mainline/buster/Dockerfile
+++ b/mainline/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.17.3
-ENV NJS_VERSION     0.3.3
+ENV NJS_VERSION     0.3.4
 ENV PKG_RELEASE     1~buster
 
 RUN set -x \

--- a/mainline/buster/Dockerfile
+++ b/mainline/buster/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION   1.17.2
+ENV NGINX_VERSION   1.17.3
 ENV NJS_VERSION     0.3.3
 ENV PKG_RELEASE     1~buster
 


### PR DESCRIPTION
Hi, here is a PR to upgrade to latest 1.17.x version. Let me now if you would like I reword, squash commits, whatever. Thank you :)

```
Changes with nginx 1.17.3                                        13 Aug 2019

    *) Security: when using HTTP/2 a client might cause excessive memory
       consumption and CPU usage (CVE-2019-9511, CVE-2019-9513,
       CVE-2019-9516).
```

See also #357