### PR TITLE
Add www-data group & user

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -10,6 +10,9 @@ RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants
     && addgroup -g 101 -S nginx \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
+    # ensure www-data user exists
+	&& addgroup -g 82 -S www-data; \
+	&& adduser -u 82 -D -S -G www-data www-data \
     && apkArch="$(cat /etc/apk/arch)" \
     && nginxPackages=" \
         nginx=${NGINX_VERSION}-r${PKG_RELEASE} \


### PR DESCRIPTION
As www-data is a widely-used user for upstream server (e.g. in PHP), adding this user into the nginx image helps solving problems regarding permissions. 
For instance, in https://github.com/nextcloud/docker/issues/883, we have to modify the image to fit our needs. If the user is pre-configured, we only need to adjust following the non-root user steps.

For the reason why its uid/gid is 82 (alpine only), see here: https://github.com/docker-library/php/blob/9b073b8852132f386d848e93105c62ae2c73c0fd/7.3/alpine3.9/fpm/Dockerfile#L35