### PR TITLE
Update supported architectures (fix #405)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -64,7 +64,7 @@ for version in "${versions[@]}"; do
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${versionAliases[@]}")
-		Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+		Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 		GitCommit: $commit
 		Directory: $version/$base
 	EOE
@@ -78,7 +78,7 @@ for version in "${versions[@]}"; do
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
-			Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+			Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE
@@ -93,7 +93,7 @@ for version in "${versions[@]}"; do
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
-			Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+			Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE


### PR DESCRIPTION
Added:
- arm32v7 for Alpine
- arm32v5 and mips64le for Debian

This could be automated with [bashbrew](https://github.com/docker-library/bashbrew).