### PR TITLE
Add NGINX_ENTRYPOINT_QUIET_LOGS environment variable

### DIFF
--- a/mainline/alpine-perl/10-listen-on-ipv6-by-default.sh
+++ b/mainline/alpine-perl/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/mainline/alpine-perl/20-envsubst-on-templates.sh
+++ b/mainline/alpine-perl/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/mainline/alpine-perl/docker-entrypoint.sh
+++ b/mainline/alpine-perl/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/mainline/alpine/10-listen-on-ipv6-by-default.sh
+++ b/mainline/alpine/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/mainline/alpine/20-envsubst-on-templates.sh
+++ b/mainline/alpine/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/mainline/alpine/docker-entrypoint.sh
+++ b/mainline/alpine/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/mainline/buster-perl/10-listen-on-ipv6-by-default.sh
+++ b/mainline/buster-perl/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/mainline/buster-perl/20-envsubst-on-templates.sh
+++ b/mainline/buster-perl/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/mainline/buster-perl/docker-entrypoint.sh
+++ b/mainline/buster-perl/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/mainline/buster/10-listen-on-ipv6-by-default.sh
+++ b/mainline/buster/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/mainline/buster/20-envsubst-on-templates.sh
+++ b/mainline/buster/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/mainline/buster/docker-entrypoint.sh
+++ b/mainline/buster/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/stable/alpine-perl/10-listen-on-ipv6-by-default.sh
+++ b/stable/alpine-perl/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/stable/alpine-perl/20-envsubst-on-templates.sh
+++ b/stable/alpine-perl/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/stable/alpine-perl/docker-entrypoint.sh
+++ b/stable/alpine-perl/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/stable/alpine/10-listen-on-ipv6-by-default.sh
+++ b/stable/alpine/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/stable/alpine/20-envsubst-on-templates.sh
+++ b/stable/alpine/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/stable/alpine/docker-entrypoint.sh
+++ b/stable/alpine/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/stable/buster-perl/10-listen-on-ipv6-by-default.sh
+++ b/stable/buster-perl/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/stable/buster-perl/20-envsubst-on-templates.sh
+++ b/stable/buster-perl/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/stable/buster-perl/docker-entrypoint.sh
+++ b/stable/buster-perl/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 

--- a/stable/buster/10-listen-on-ipv6-by-default.sh
+++ b/stable/buster/10-listen-on-ipv6-by-default.sh
@@ -18,10 +18,10 @@ if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: Can not modify /$DEFAULT_CONF_FILE (read-only file system?), exiting"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo "$ME: IPv6 listen already enabled, exiting"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: IPv6 listen already enabled, exiting"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
@@ -30,7 +30,7 @@ else
     exit 0
 fi
 
-echo "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
@@ -56,6 +56,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+echo >&3 "$ME: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/stable/buster/20-envsubst-on-templates.sh
+++ b/stable/buster/20-envsubst-on-templates.sh
@@ -22,7 +22,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo "$ME: Running envsubst on $template to $output_path"
+    echo >&3 "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/stable/buster/docker-entrypoint.sh
+++ b/stable/buster/docker-entrypoint.sh
@@ -3,29 +3,35 @@
 
 set -e
 
+if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+    exec 3>&1
+else
+    exec 3>/dev/null
+fi
+
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -n | while read -r f; do
             case "$f" in
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo "$0: Launching $f";
+                        echo >&3 "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo "$0: Ignoring $f, not executable";
+                        echo >&3 "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo "$0: Ignoring $f";;
+                *) echo >&3 "$0: Ignoring $f";;
             esac
         done
 
-        echo "$0: Configuration complete; ready for start up"
+        echo >&3 "$0: Configuration complete; ready for start up"
     else
-        echo "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 


### PR DESCRIPTION
**Related issue**: #421

This pull-request adds an environment variable `NGINX_ENTRYPOINT_QUIET_LOGS` to silence information messages when starting up.

By default, verbosity is identical. When this environment variable is defined, the entry point silence information messages, but keep errror messages (on stderr).