### PR TITLE
Use /bin/sh in shebang instead of /usr/bin/env

### DIFF
--- a/mainline/alpine-perl/docker-entrypoint.sh
+++ b/mainline/alpine-perl/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/mainline/alpine/docker-entrypoint.sh
+++ b/mainline/alpine/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/mainline/buster-perl/docker-entrypoint.sh
+++ b/mainline/buster-perl/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/mainline/buster/docker-entrypoint.sh
+++ b/mainline/buster/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/stable/alpine-perl/docker-entrypoint.sh
+++ b/stable/alpine-perl/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/stable/alpine/docker-entrypoint.sh
+++ b/stable/alpine/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/stable/buster-perl/docker-entrypoint.sh
+++ b/stable/buster-perl/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e

--- a/stable/buster/docker-entrypoint.sh
+++ b/stable/buster/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # vim:sw=4:ts=4:et
 
 set -e


### PR DESCRIPTION
A POSIX compatible sh is guaranteed to be available as /bin/sh. By not
using /usr/bin/env simply whitelisting /docker-entrypoint.sh within
mandatory access control frameworks, such as AppArmor, is sufficient.
When /usr/bin/env is used /docker-entrypoint.sh and the shell that
provides sh (e.g. /bin/dash for debian based images) need to be
whitelisted, increasing the possible attack area, by providing access
to a full shell.