### PR TITLE
Use SIGQUIT instead of SIGTERM for graceful shutdown of nginx

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -120,6 +120,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -119,6 +119,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -111,6 +111,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -110,6 +110,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -120,6 +120,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -119,6 +119,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/debian-perl/Dockerfile
+++ b/stable/debian-perl/Dockerfile
@@ -111,6 +111,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -110,6 +110,6 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Resolves #377 

Replace stopsignal SIGTERM with SIGQUIT to ensure a graceful shutdown.
Tested each changed Dockerfile using the [Dockerfile](https://gist.github.com/nottrobin/79087f07efab61f013c6e7e519a96ad8) provided by @nottrobin in #337.
