### PR TITLE
Bump 1.18.0 PKG_RELEASE from 1 to 2

### DIFF
--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.18.0
 ENV NJS_VERSION   0.4.4
-ENV PKG_RELEASE   1
+ENV PKG_RELEASE   2
 
 RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION 1.18.0
 ENV NJS_VERSION   0.4.4
-ENV PKG_RELEASE   1
+ENV PKG_RELEASE   2
 
 RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants

--- a/stable/buster-perl/Dockerfile
+++ b/stable/buster-perl/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.18.0
 ENV NJS_VERSION     0.4.4
-ENV PKG_RELEASE     1~buster
+ENV PKG_RELEASE     2~buster
 
 RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
 ENV NGINX_VERSION   1.18.0
 ENV NJS_VERSION     0.4.4
-ENV PKG_RELEASE     1~buster
+ENV PKG_RELEASE     2~buster
 
 RUN set -x \
 # create nginx user/group first, to be consistent throughout docker variants


### PR DESCRIPTION
I have a place with hard dependency on `1.18.0~2` and I couldn't use the official Nginx image before it would be updated.

I don't know for sure if it will work with your build system as I see `1.18.0~2` package available in https://nginx.org/packages/debian/ but not in https://nginx.org/packages/mainline/debian/.