### PR TITLE
Remove non-alphanumeric characters from module name when installing it.

### DIFF
--- a/modules/Dockerfile.alpine
+++ b/modules/Dockerfile.alpine
@@ -62,6 +62,6 @@ ARG ENABLED_MODULES
 COPY --from=builder /tmp/packages /tmp/packages
 RUN set -ex \
     && for module in $ENABLED_MODULES; do \
-           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
+           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-$(echo $module | tr -dc '[[:alpha:]]')-${NGINX_VERSION}*.apk; \
        done \
     && rm -rf /tmp/packages

--- a/modules/README.md
+++ b/modules/README.md
@@ -65,6 +65,9 @@ echo
 0 directories, 3 files
 ```
 
+Note that the name of the directory needs to be named like the module that
+will be built.
+
 The scripts expect one file to always exist for a module you wish to build
 manually: `source`.  It should contain a link to a zip/tarball source code of a
 module you want to build.  In `build-deps` you can specify build dependencies


### PR DESCRIPTION
I had a couple of problems while building nginx-upload-progress-module
https://github.com/masterzen/nginx-upload-progress-module

First the build was refusing to build the `-dbg` version. Renaming my directory from `nginx-upload-progress-module` to `ngx_http_uploadprogress_module` solved. Added a some a line to docs to clarify that.

Then in the final step tries to install `nginx-module-ngx_http_uploadprogress_module-1.19.10*.apk` but the file generated is
`nginx-module-ngxhttpuploadprogressmodule-1.19.10-r1.apk`

Added a cleanup of the module name to circumvent that.