### PR TITLE
Manually specify nginx worker processes number

### DIFF
--- a/entrypoint/30-tune-worker-processes.sh
+++ b/entrypoint/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/alpine-perl/30-tune-worker-processes.sh
+++ b/mainline/alpine-perl/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/alpine/30-tune-worker-processes.sh
+++ b/mainline/alpine/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/debian-perl/30-tune-worker-processes.sh
+++ b/mainline/debian-perl/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/debian/30-tune-worker-processes.sh
+++ b/mainline/debian/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/alpine-perl/30-tune-worker-processes.sh
+++ b/stable/alpine-perl/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/alpine/30-tune-worker-processes.sh
+++ b/stable/alpine/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/debian-perl/30-tune-worker-processes.sh
+++ b/stable/debian-perl/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/debian/30-tune-worker-processes.sh
+++ b/stable/debian/30-tune-worker-processes.sh
@@ -185,4 +185,7 @@ ncpu=$( printf "%s\n%s\n%s\n%s\n%s\n" \
                | sort -n \
                | head -n 1 )
 
+# NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE has higher priority if it is a positive integer
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-0}" -gt 0 ] 2>/dev/null && ncpu=${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE}
+
 sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf


### PR DESCRIPTION
By setting environment **NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE** to a positive integer number to define nginx worker process number.

### What change's about env NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE ?

- before this commit: 2b064090d1ebb724865ce7e6f4b6cc64c4c5cd6e
- after this commit: add feature: user defined nginx worker processes number (must a positive integer) will be applied to nginx.conf，other value (eg: auto, true) work as usual.

### What propose of this commit ？
Offer a graceful way to config the nginx worker processes number without mount nginx.conf file outside the container or rebuild docker image. 
Useful when you want to set the nginx worker processes number when nginx running on a high performance multi-core CPU server like 64CPU128GB without [lxcfs](https://github.com/lxc/lxcfs) support.

### Use case

- Running nginx docker by docker-compose or kubernetes，want to set the nginx worker processes number and without [lxcfs](https://github.com/lxc/lxcfs) support.
