### PR TITLE
Better ENV variables handling.

### DIFF
--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -10,7 +10,7 @@ auto_envsubst() {
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
 
   local template defined_envs relative_path output_path subdir
-  defined_envs=$(printf '${%s} ' $(env -0 | cut -z -d= -f1 | tr -d "\0"))
+  defined_envs=$(cat /proc/self/environ | xargs -I{}  -0 -n1 sh -c 'echo "{}" | sed -n "1 s/^\([^=]*\)=.*$/\${\1} /p"');
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
     echo >&3 "$ME: ERROR: $template_dir exists, but $output_dir is not writable"

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -10,7 +10,7 @@ auto_envsubst() {
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
 
   local template defined_envs relative_path output_path subdir
-  defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
+  defined_envs=$(printf '${%s} ' $(env -0 | cut -z -d= -f1 | tr -d "\0"))
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
     echo >&3 "$ME: ERROR: $template_dir exists, but $output_dir is not writable"

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -10,7 +10,7 @@ auto_envsubst() {
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
 
   local template defined_envs relative_path output_path subdir
-  defined_envs=$(cat /proc/self/environ | xargs -I{}  -0 -n1 sh -c 'echo "{}" | sed -n "1 s/^\([^=]*\)=.*$/\${\1} /p"');
+  defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c 'echo "$@" | grep -oEm1 "^[^=]+"' --));
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
     echo >&3 "$ME: ERROR: $template_dir exists, but $output_dir is not writable"


### PR DESCRIPTION
In case when env contain variables with newlines, the variables
substitution script fails, trying to use non-existent variables. Change
env mode to delim different env vars in output with NULL-byte instead of
newline.