### PR TITLE
Remove i386 from packages built by upstream for Debian

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -30,7 +30,7 @@ RUN set -x \
     && nginxPackages="%%PACKAGES%%
     " \
     && case "$dpkgArch" in \
-        amd64|i386|arm64) \
+        amd64|arm64) \
 # arches officialy built by upstream
             echo "deb %%PACKAGEREPO%% %%DEBIAN_VERSION%% nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -41,7 +41,7 @@ RUN set -x \
         nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE} \
     " \
     && case "$dpkgArch" in \
-        amd64|i386|arm64) \
+        amd64|arm64) \
 # arches officialy built by upstream
             echo "deb https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x \
         nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE} \
     " \
     && case "$dpkgArch" in \
-        amd64|i386|arm64) \
+        amd64|arm64) \
 # arches officialy built by upstream
             echo "deb https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \


### PR DESCRIPTION
`i386` packages are not built anymore for `bullseye` https://github.com/nginxinc/docker-nginx/issues/561#issuecomment-965771601