### PR TITLE
updating package xz-libs to clear a security issue - github issue #65…

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -63,6 +63,7 @@ RUN set -x \
                 bash \
                 alpine-sdk \
                 findutils \
+            &&  apk update xz-libs \    
             && su nobody -s /bin/sh -c " \
                 export HOME=${tempDir} \
                 && cd ${tempDir} \


### PR DESCRIPTION
updating package xz-libs to clear a security issue **CVE-2022-1271** - github issue [#652](https://github.com/nginxinc/docker-nginx/issues/652) 

