### PR TITLE
Regenerate Alpine Dockerfiles based on latest templates

### DIFF
--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -53,7 +53,7 @@ RUN set -x \
                 libc-dev \
                 make \
                 openssl-dev \
-                pcre-dev \
+                pcre2-dev \
                 zlib-dev \
                 linux-headers \
                 libxslt-dev \

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -52,7 +52,7 @@ RUN set -x \
                 libc-dev \
                 make \
                 openssl-dev \
-                pcre-dev \
+                pcre2-dev \
                 zlib-dev \
                 linux-headers \
                 libxslt-dev \


### PR DESCRIPTION
In d07b71be964b53184d829dfd00e2eaa51e4e6ecf a build dependency was changed, but this change was not applied to the stable Dockerfiles. 

Running `update.sh` on the current `master` branch yields the changes in this PR.