### PR TITLE
Update mainline to Alpine 3.16

### DIFF
--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.15
+FROM alpine:3.16
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/update.sh
+++ b/update.sh
@@ -35,7 +35,7 @@ declare -A debian=(
 )
 
 declare -A alpine=(
-    [mainline]='3.15'
+    [mainline]='3.16'
     [stable]='3.16'
 )
 


### PR DESCRIPTION
Alpine 3.16 was [released](https://alpinelinux.org/posts/Alpine-3.16.0-released.html) yesterday. This PR updates the `mainline` image to use the latest Alpine version.