### PR TITLE
FIX argument list too long by not collecting env

### DIFF
--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -10,7 +10,6 @@ auto_envsubst() {
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
 
   local template defined_envs relative_path output_path subdir
-  defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
     echo >&3 "$ME: ERROR: $template_dir exists, but $output_dir is not writable"
@@ -23,7 +22,8 @@ auto_envsubst() {
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
     echo >&3 "$ME: Running envsubst on $template to $output_path"
-    envsubst "$defined_envs" < "$template" > "$output_path"
+    defined_envs=$(grep -oE '\$\{.*\}' "${template}")
+    envsubst $defined_envs < "$template" > "$output_path"
   done
 }
 


### PR DESCRIPTION
When there are many environment variables defined for the image that nginx runs in, the envsubst script fails to work with the following error message:
```
20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/default.conf.template to /etc/nginx/conf.d/default.conf
/docker-entrypoint.d/20-envsubst-on-templates.sh: line 26: envsubst: Argument list too long
```
This is because defined_envs is used to collect the whole environment into one line and passed to envsubst, making for a very long command. We can fix this by not using defined_envs at all; this way envsubst will look for anything in current environment by default. However variables like $uri will get replaced by empty strings in this case, so some special handling is needed.

If we limit the environment lookups to variables actually defined in any template files in the templates directory, reading those files for `${variable}` style references, and creating defined_envs based on that, we avoid overriding simple format references like `$uri`. However once the number of variables used in a template grows long enough, it would hit the same problem. In this case, users can avoid the issue by splitting their variable use to different templates.

This could still be improved by grepping env for the found template variable references so only non-empty substitutions are done. However that might result in a lot of grep statements. What do you think?