### PR TITLE
docker-entrypoint: 30-tune-worker-processes.sh: cgroups2 workaround

### DIFF
--- a/entrypoint/30-tune-worker-processes.sh
+++ b/entrypoint/30-tune-worker-processes.sh
@@ -158,7 +158,7 @@ __EOF__
     "/")
       foundroot="${found##* }$mountpoint"
       ;;
-    "$mountpoint")
+    "$mountpoint" | /../*)
       foundroot="${found##* }"
       ;;
   esac


### PR DESCRIPTION
cgroups2 may be set in weird way:

```
$ podman run --rm --network=host debian:stable-slim sh -c 'grep cgroup /proc/self/mountinfo ; echo ; cat /proc/self/cgroup'
754 752 0:27 /../../../../../.. /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw,nsdelegate,memory_recursiveprot

0::/
```

add workaround for that case

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>