### PR TITLE
docker-entrypoint: support socket activation

### DIFF
--- a/entrypoint/10-listen-on-ipv6-by-default.sh
+++ b/entrypoint/10-listen-on-ipv6-by-default.sh
@@ -3,52 +3,58 @@
 
 set -e
 
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
 ME=$(basename $0)
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available
 if [ ! -f "/proc/net/if_inet6" ]; then
-    echo >&3 "$ME: info: ipv6 not available"
+    entrypoint_log "$ME: info: ipv6 not available"
     exit 0
 fi
 
 if [ ! -f "/$DEFAULT_CONF_FILE" ]; then
-    echo >&3 "$ME: info: /$DEFAULT_CONF_FILE is not a file or does not exist"
+    entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE is not a file or does not exist"
     exit 0
 fi
 
 # check if the file can be modified, e.g. not on a r/o filesystem
-touch /$DEFAULT_CONF_FILE 2>/dev/null || { echo >&3 "$ME: info: can not modify /$DEFAULT_CONF_FILE (read-only file system?)"; exit 0; }
+touch /$DEFAULT_CONF_FILE 2>/dev/null || { entrypoint_log "$ME: info: can not modify /$DEFAULT_CONF_FILE (read-only file system?)"; exit 0; }
 
 # check if the file is already modified, e.g. on a container restart
-grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { echo >&3 "$ME: info: IPv6 listen already enabled"; exit 0; }
+grep -q "listen  \[::]\:80;" /$DEFAULT_CONF_FILE && { entrypoint_log "$ME: info: IPv6 listen already enabled"; exit 0; }
 
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release
 else
-    echo >&3 "$ME: info: can not guess the operating system"
+    entrypoint_log "$ME: info: can not guess the operating system"
     exit 0
 fi
 
-echo >&3 "$ME: info: Getting the checksum of /$DEFAULT_CONF_FILE"
+entrypoint_log "$ME: info: Getting the checksum of /$DEFAULT_CONF_FILE"
 
 case "$ID" in
     "debian")
         CHECKSUM=$(dpkg-query --show --showformat='${Conffiles}\n' nginx | grep $DEFAULT_CONF_FILE | cut -d' ' -f 3)
         echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | md5sum -c - >/dev/null 2>&1 || {
-            echo >&3 "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
+            entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
             exit 0
         }
         ;;
     "alpine")
         CHECKSUM=$(apk manifest nginx 2>/dev/null| grep $DEFAULT_CONF_FILE | cut -d' ' -f 1 | cut -d ':' -f 2)
         echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | sha1sum -c - >/dev/null 2>&1 || {
-            echo >&3 "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
+            entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
             exit 0
         }
         ;;
     *)
-        echo >&3 "$ME: info: Unsupported distribution"
+        entrypoint_log "$ME: info: Unsupported distribution"
         exit 0
         ;;
 esac
@@ -56,6 +62,6 @@ esac
 # enable ipv6 on default.conf listen sockets
 sed -i -E 's,listen       80;,listen       80;\n    listen  [::]:80;,' /$DEFAULT_CONF_FILE
 
-echo >&3 "$ME: info: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
+entrypoint_log "$ME: info: Enabled listen on IPv6 in /$DEFAULT_CONF_FILE"
 
 exit 0

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -4,6 +4,12 @@ set -e
 
 ME=$(basename $0)
 
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
 auto_envsubst() {
   local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
@@ -13,7 +19,7 @@ auto_envsubst() {
   defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
-    echo >&3 "$ME: ERROR: $template_dir exists, but $output_dir is not writable"
+    entrypoint_log "$ME: ERROR: $template_dir exists, but $output_dir is not writable"
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
@@ -22,7 +28,7 @@ auto_envsubst() {
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
-    echo >&3 "$ME: Running envsubst on $template to $output_path"
+    entrypoint_log "$ME: Running envsubst on $template to $output_path"
     envsubst "$defined_envs" < "$template" > "$output_path"
   done
 }

--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -3,44 +3,44 @@
 
 set -e
 
-if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
-    exec 3>&1
-else
-    exec 3>/dev/null
-fi
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        echo >&3 "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+        entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        echo >&3 "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
         find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then
-                        echo >&3 "$0: Sourcing $f";
+                        entrypoint_log "$0: Sourcing $f";
                         source "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo >&3 "$0: Ignoring $f, not executable";
+                        entrypoint_log "$0: Ignoring $f, not executable";
                     fi
                     ;;
                 *.sh)
                     if [ -x "$f" ]; then
-                        echo >&3 "$0: Launching $f";
+                        entrypoint_log "$0: Launching $f";
                         "$f"
                     else
                         # warn on shell scripts without exec bit
-                        echo >&3 "$0: Ignoring $f, not executable";
+                        entrypoint_log "$0: Ignoring $f, not executable";
                     fi
                     ;;
-                *) echo >&3 "$0: Ignoring $f";;
+                *) entrypoint_log "$0: Ignoring $f";;
             esac
         done
 
-        echo >&3 "$0: Configuration complete; ready for start up"
+        entrypoint_log "$0: Configuration complete; ready for start up"
     else
-        echo >&3 "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+        entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
     fi
 fi
 


### PR DESCRIPTION
Although there is an open feature request to Nginx ("Add optional systemd socket activation support"
https://trac.nginx.org/nginx/ticket/237),
it's possible to use socket activation
by using the environment variable `NGINX`.

When systemd runs a socket-activated service,
systemd sets the environment variables LISTEN_FDS and LISTEN_FDNAMES for the launched process.
In docker-entrypoint.sh set NGINX from a translated LISTEN_FDS value.

For example:

LISTEN_FDS=1
translates to
NGINX=3;

LISTEN_FDS=2
translates to
NGINX=3;4;

LISTEN_FDS=3
translates to
NGINX=3;4;5;

Don't close the file descriptor 3 in the logging machinery.

Fixes #702

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>