### PR TITLE
env file for 20-envsubst-on-templates.sh

### DIFF
--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/mainline/alpine-perl/20-envsubst-on-templates.sh
+++ b/mainline/alpine-perl/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/mainline/alpine-slim/20-envsubst-on-templates.sh
+++ b/mainline/alpine-slim/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/mainline/alpine/20-envsubst-on-templates.sh
+++ b/mainline/alpine/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/mainline/debian-perl/20-envsubst-on-templates.sh
+++ b/mainline/debian-perl/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/mainline/debian/20-envsubst-on-templates.sh
+++ b/mainline/debian/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/stable/alpine-perl/20-envsubst-on-templates.sh
+++ b/stable/alpine-perl/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/stable/alpine-slim/20-envsubst-on-templates.sh
+++ b/stable/alpine-slim/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/stable/alpine/20-envsubst-on-templates.sh
+++ b/stable/alpine/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/stable/debian-perl/20-envsubst-on-templates.sh
+++ b/stable/debian-perl/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));

--- a/stable/debian/20-envsubst-on-templates.sh
+++ b/stable/debian/20-envsubst-on-templates.sh
@@ -15,6 +15,14 @@ auto_envsubst() {
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
+  local env_file="${NGINX_ENV_FILE:-.env}"
+
+  if [ -f "${env_file}" ]; then
+    entrypoint_log "$ME: Source file ${env_file}"
+    set -a
+    . "$(realpath "${env_file}")"
+    set +a
+  fi
 
   local template defined_envs relative_path output_path subdir
   defined_envs=$(printf '${%s} ' $(xargs -0n1 -a /proc/self/environ sh -c "echo \"\$@\" | grep -- \"${filter}\" | grep -oEm1 \"^[^=]+\"" --));


### PR DESCRIPTION
Problem: there is no way to provide additional variables to `20-envsubst-on-templates.sh` script.
For example I have some `01-script.sh` which calculates some date and wants to export a result somehow.
A real case, - I faced with the following problem: I need to get FQDN from hostname and put result in a new variable.
Simple `export` does not work.

So I implemented that elegant way to add variables in runtime using separate file `.env`.
