### PR TITLE
Replace envsubst with Perl script

### DIFF
--- a/Dockerfile-alpine-slim.template
+++ b/Dockerfile-alpine-slim.template
@@ -76,23 +76,6 @@ RUN set -x \
     && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
     && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
     && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
-# Bring in gettext so we can get `envsubst`, then throw
-# the rest away. To do this, we need to install `gettext`
-# then move `envsubst` out of the way so `gettext` can
-# be deleted completely, then move `envsubst` back.
-    && apk add --no-cache --virtual .gettext gettext \
-    && mv /usr/bin/envsubst /tmp/ \
-    \
-    && runDeps="$( \
-        scanelf --needed --nobanner /tmp/envsubst \
-            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-            | sort -u \
-            | xargs -r apk info --installed \
-            | sort -u \
-    )" \
-    && apk add --no-cache $runDeps \
-    && apk del .gettext \
-    && mv /tmp/envsubst /usr/local/bin/ \
 # Bring in tzdata so users could set the timezones through the environment
 # variables
     && apk add --no-cache tzdata \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -82,23 +82,6 @@ RUN set -x \
     && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
     && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
     && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
-# Bring in gettext so we can get `envsubst`, then throw
-# the rest away. To do this, we need to install `gettext`
-# then move `envsubst` out of the way so `gettext` can
-# be deleted completely, then move `envsubst` back.
-    && apk add --no-cache --virtual .gettext gettext \
-    && mv /usr/bin/envsubst /tmp/ \
-    \
-    && runDeps="$( \
-        scanelf --needed --nobanner /tmp/envsubst \
-            | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
-            | sort -u \
-            | xargs -r apk info --installed \
-            | sort -u \
-    )" \
-    && apk add --no-cache $runDeps \
-    && apk del .gettext \
-    && mv /tmp/envsubst /usr/local/bin/ \
 # Bring in tzdata so users could set the timezones through the environment
 # variables
     && apk add --no-cache tzdata \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -76,7 +76,6 @@ RUN set -x \
     \
     && apt-get install --no-install-recommends --no-install-suggests -y \
                         $nginxPackages \
-                        gettext-base \
                         curl \
     && apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
     \

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -14,7 +14,6 @@ auto_envsubst() {
   local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
-  local filter="${NGINX_ENVSUBST_FILTER:-}"
 
   local template relative_path output_path subdir
   [ -d "$template_dir" ] || return 0
@@ -29,7 +28,7 @@ auto_envsubst() {
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
     entrypoint_log "$ME: Running envsubst on $template to $output_path"
-    perl -pe "s|\$({)?($filter\w*)(?(1)})|$ENV{$2} // $&|ge" < "$template" > "$output_path"
+    perl -pe 's|\$(\{)?($ENV{NGINX_ENVSUBST_FILTER}\w*)(?(1)\})|$ENV{$2} // $&|ge' < "$template" > "$output_path"
   done
 }
 

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -14,6 +14,7 @@ auto_envsubst() {
   local template_dir="${NGINX_ENVSUBST_TEMPLATE_DIR:-/etc/nginx/templates}"
   local suffix="${NGINX_ENVSUBST_TEMPLATE_SUFFIX:-.template}"
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
+  local filter="${NGINX_ENVSUBST_FILTER:-}"
 
   local template relative_path output_path subdir
   [ -d "$template_dir" ] || return 0
@@ -28,7 +29,7 @@ auto_envsubst() {
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
     entrypoint_log "$ME: Running envsubst on $template to $output_path"
-    perl -pe 's|\$(\{)?($ENV{NGINX_ENVSUBST_FILTER}\w*)(?(1)\})|$ENV{$2} // $&|ge' < "$template" > "$output_path"
+    perl -pe 's|\$(\{)?('$filter'\w*)(?(1)\})|$ENV{$2} // $&|ge' < "$template" > "$output_path"
   done
 }
 

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -16,8 +16,7 @@ auto_envsubst() {
   local output_dir="${NGINX_ENVSUBST_OUTPUT_DIR:-/etc/nginx/conf.d}"
   local filter="${NGINX_ENVSUBST_FILTER:-}"
 
-  local template defined_envs relative_path output_path subdir
-  defined_envs=$(printf '${%s} ' $(awk "END { for (name in ENVIRON) { print ( name ~ /${filter}/ ) ? name : \"\" } }" < /dev/null ))
+  local template relative_path output_path subdir
   [ -d "$template_dir" ] || return 0
   if [ ! -w "$output_dir" ]; then
     entrypoint_log "$ME: ERROR: $template_dir exists, but $output_dir is not writable"
@@ -30,7 +29,7 @@ auto_envsubst() {
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
     entrypoint_log "$ME: Running envsubst on $template to $output_path"
-    envsubst "$defined_envs" < "$template" > "$output_path"
+    perl -pe "s|\$({)?($filter\w*)(?(1)})|$ENV{$2} // $&|ge" < "$template" > "$output_path"
   done
 }
 


### PR DESCRIPTION
Replace envsubst usage with a Perl script based on https://unix.stackexchange.com/a/294836 to remove the need of installing `gettext` and using `envsubst`.

Would be great if somebody knowing Perl check the script (I don't know Perl very well)...