### PR TITLE
Allow extending environment in entrypoints

### DIFF
--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -28,7 +28,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
                 *.sh)
                     if [ -x "$f" ]; then
                         entrypoint_log "$0: Launching $f";
-                        "$f"
+                        . "$f"
                     else
                         # warn on shell scripts without exec bit
                         entrypoint_log "$0: Ignoring $f, not executable";


### PR DESCRIPTION
I need to create a custom docker image based on **nginx**. I have created a script `docker-entrypoints.d/00-prepare.sh`:
```sh
#!/bin/sh

if [ "$ENABLE_SOME_LOGIC" == "true" ]; then
   export SOME_VARIABLE="some_value"
fi
```
so that it executes before `20-envsubst-on-templates.sh` and I can use that variables in conf templates.

To my surprise I've found that the `export` doesn't work.