### PR TITLE
Following symlinks when docker-entrypoint.sh starts.

### DIFF
--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -10,7 +10,7 @@ entrypoint_log() {
 }
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    if /usr/bin/find "/docker-entrypoint.d/" -follow -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"

--- a/mainline/alpine-slim/docker-entrypoint.sh
+++ b/mainline/alpine-slim/docker-entrypoint.sh
@@ -10,7 +10,7 @@ entrypoint_log() {
 }
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    if /usr/bin/find "/docker-entrypoint.d/" -follow -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"

--- a/mainline/debian/docker-entrypoint.sh
+++ b/mainline/debian/docker-entrypoint.sh
@@ -10,7 +10,7 @@ entrypoint_log() {
 }
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    if /usr/bin/find "/docker-entrypoint.d/" -follow -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"

--- a/stable/alpine-slim/docker-entrypoint.sh
+++ b/stable/alpine-slim/docker-entrypoint.sh
@@ -10,7 +10,7 @@ entrypoint_log() {
 }
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    if /usr/bin/find "/docker-entrypoint.d/" -follow -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"

--- a/stable/debian/docker-entrypoint.sh
+++ b/stable/debian/docker-entrypoint.sh
@@ -10,7 +10,7 @@ entrypoint_log() {
 }
 
 if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    if /usr/bin/find "/docker-entrypoint.d/" -follow -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"


### PR DESCRIPTION
Some k8s implentations (I use k0s v1.25.2+k0s.0) use symlinks when mounting ConfigMap as volume.

![image](https://user-images.githubusercontent.com/1270667/208284731-f2e5538e-ceca-40dd-ba9b-4abd3c2e0f80.png)

Following `find` supports symbolic linked contents. But the first `find` does not follow symlinks, it is not processed.

https://github.com/nginxinc/docker-nginx/blob/5ce65c3efd395ee2d82d32670f233140e92dba99/entrypoint/docker-entrypoint.sh#L17

---

Since `find` (L17) includes dotdirs when following symlinks, found shell scripts are evaluated multiple times (at my environment.).
Excluding dotdirs(like below) will resolve it , but I'm afraid of breaking backward compatibility.

```sh
find "/docker-entrypoint.d/" -follow -type d -name '.*' -prune -o -type f -print
```