### PR TITLE
Change the loop that executes .envsh from pipeline(while + read) to for.

### DIFF
--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        for f in `find "/docker-entrypoint.d/" -follow -type f -print | sort -V`; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then

--- a/mainline/alpine-slim/docker-entrypoint.sh
+++ b/mainline/alpine-slim/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        for f in `find "/docker-entrypoint.d/" -follow -type f -print | sort -V`; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then

--- a/mainline/debian/docker-entrypoint.sh
+++ b/mainline/debian/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        for f in `find "/docker-entrypoint.d/" -follow -type f -print | sort -V`; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then

--- a/stable/alpine-slim/docker-entrypoint.sh
+++ b/stable/alpine-slim/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        for f in `find "/docker-entrypoint.d/" -follow -type f -print | sort -V`; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then

--- a/stable/debian/docker-entrypoint.sh
+++ b/stable/debian/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
         entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        for f in `find "/docker-entrypoint.d/" -follow -type f -print | sort -V`; do
             case "$f" in
                 *.envsh)
                     if [ -x "$f" ]; then


### PR DESCRIPTION
close #745
Because pipeline is executed in a subshell, exported environment variables are not reflected in the parent shell.