### PR TITLE
Run docker-entrypoint.d scripts for any CMD.

### DIFF
--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -9,39 +9,37 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
-    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
-        entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+    entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 
-        entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
-        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
-            case "$f" in
-                *.envsh)
-                    if [ -x "$f" ]; then
-                        entrypoint_log "$0: Sourcing $f";
-                        . "$f"
-                    else
-                        # warn on shell scripts without exec bit
-                        entrypoint_log "$0: Ignoring $f, not executable";
-                    fi
-                    ;;
-                *.sh)
-                    if [ -x "$f" ]; then
-                        entrypoint_log "$0: Launching $f";
-                        "$f"
-                    else
-                        # warn on shell scripts without exec bit
-                        entrypoint_log "$0: Ignoring $f, not executable";
-                    fi
-                    ;;
-                *) entrypoint_log "$0: Ignoring $f";;
-            esac
-        done
+    entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
+    find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+        case "$f" in
+            *.envsh)
+                if [ -x "$f" ]; then
+                    entrypoint_log "$0: Sourcing $f";
+                    . "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    entrypoint_log "$0: Ignoring $f, not executable";
+                fi
+                ;;
+            *.sh)
+                if [ -x "$f" ]; then
+                    entrypoint_log "$0: Launching $f";
+                    "$f"
+                else
+                    # warn on shell scripts without exec bit
+                    entrypoint_log "$0: Ignoring $f, not executable";
+                fi
+                ;;
+            *) entrypoint_log "$0: Ignoring $f";;
+        esac
+    done
 
-        entrypoint_log "$0: Configuration complete; ready for start up"
-    else
-        entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
-    fi
+    entrypoint_log "$0: Configuration complete; ready for start up"
+else
+    entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
 fi
 
 exec "$@"


### PR DESCRIPTION
Why is that check [`if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]`](https://github.com/nginxinc/docker-nginx/blob/761fffeba0d867d6e80d38998073e0eaa456bb02/entrypoint/docker-entrypoint.sh#L12) needed in `docker-entrypoint.sh`?
I think it will be usefull to run `docker-entrypoint.d/` scripts regardless of arguments passed.
This will allow to specify a custom `CMD` to execute, while still perform `/etc/nginx/templates` substitutions.

Related issue https://github.com/nginxinc/docker-nginx/issues/422 .