### PR TITLE
Upgrade openssl-dev package to keep libssl up to date

### DIFF
--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -21,6 +21,7 @@ RUN set -x \
 # install prerequisites for public key and pkg-oss checks
     && apk add --no-cache --virtual .checksum-deps \
         openssl \
+	openssl-dev \
     && case "$apkArch" in \
         x86_64|aarch64) \
 # arches officially built by upstream


### PR DESCRIPTION
The current base image, alpine 3.17, does not bundle with the latest version of libssl and the docker build process does not update the libssl library. So building the image does not guaranteee to have installed the latest version. This change take care to build the image using the latest libssl version available from alpine packages repository.