### PR TITLE
Update to Alpine 3.18

### DIFF
--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.17
+FROM alpine:3.18
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/stable/alpine-slim/Dockerfile
+++ b/stable/alpine-slim/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.17
+FROM alpine:3.18
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/update.sh
+++ b/update.sh
@@ -35,8 +35,8 @@ declare -A debian=(
 )
 
 declare -A alpine=(
-    [mainline]='3.17'
-    [stable]='3.17'
+    [mainline]='3.18'
+    [stable]='3.18'
 )
 
 # When we bump njs version in a stable release we don't move the tag in the


### PR DESCRIPTION
This change updates the mainline and stable Alpine images to use 3.18.0 instead of 3.17.0.

Release post:
https://alpinelinux.org/posts/Alpine-3.18.0-released.html