### PR TITLE
Added a local resolver entrypoint script.

### DIFF
--- a/Dockerfile-alpine-slim.template
+++ b/Dockerfile-alpine-slim.template
@@ -104,6 +104,7 @@ RUN set -x \
 
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
+COPY 15-local-resolvers.envsh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
 COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -97,6 +97,7 @@ RUN set -x \
 
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
+COPY 15-local-resolvers.envsh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
 COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+if [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS}" ]; then
+  export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+fi


### PR DESCRIPTION
If enabled via NGINX_ENTRYPOINT_LOCAL_RESOLVERS variable, this script will populate NGINX_LOCAL_RESOLVERS variable that can be used in the envsubst-base templating to populate the configuration files.

Fixes https://github.com/nginxinc/docker-nginx/issues/673