### PR TITLE
Fix unbound variable issue in local resolver entrypoint script

### DIFF
--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -6,6 +6,6 @@ set -eu
 LC_ALL=C
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-if [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS}" ]; then
+if [ ! -z "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS+defined}" ]; then
   export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
 fi


### PR DESCRIPTION
Using the `master` branch here to build an image results in the following error, when trying to run the built image:
```
$ docker run --rm my-image-built-with-master
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Unsupported distribution
/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
/docker-entrypoint.sh: 9: /docker-entrypoint.d/15-local-resolvers.envsh: NGINX_ENTRYPOINT_LOCAL_RESOLVERS: parameter not set
```

This pull request fixes the unset parameter issue :)