### PR TITLE
fix: Address Alpine bug and shell linter warnings

### DIFF
--- a/Dockerfile-alpine-perl.template
+++ b/Dockerfile-alpine-perl.template
@@ -66,6 +66,6 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi

--- a/Dockerfile-alpine-slim.template
+++ b/Dockerfile-alpine-slim.template
@@ -73,9 +73,9 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in gettext so we can get `envsubst`, then throw
 # the rest away. To do this, we need to install `gettext`
 # then move `envsubst` out of the way so `gettext` can

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -71,8 +71,8 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in curl and ca-certificates to make registering on DNS SD easier
     && apk add --no-cache curl ca-certificates

--- a/entrypoint/10-listen-on-ipv6-by-default.sh
+++ b/entrypoint/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/entrypoint/20-envsubst-on-templates.sh
+++ b/entrypoint/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/entrypoint/30-tune-worker-processes.sh
+++ b/entrypoint/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/entrypoint/docker-entrypoint.sh
+++ b/entrypoint/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -77,6 +77,6 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi

--- a/mainline/alpine-slim/10-listen-on-ipv6-by-default.sh
+++ b/mainline/alpine-slim/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/mainline/alpine-slim/15-local-resolvers.envsh
+++ b/mainline/alpine-slim/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/mainline/alpine-slim/20-envsubst-on-templates.sh
+++ b/mainline/alpine-slim/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/mainline/alpine-slim/30-tune-worker-processes.sh
+++ b/mainline/alpine-slim/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -79,9 +79,9 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in gettext so we can get `envsubst`, then throw
 # the rest away. To do this, we need to install `gettext`
 # then move `envsubst` out of the way so `gettext` can

--- a/mainline/alpine-slim/docker-entrypoint.sh
+++ b/mainline/alpine-slim/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -81,8 +81,8 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in curl and ca-certificates to make registering on DNS SD easier
     && apk add --no-cache curl ca-certificates

--- a/mainline/debian/10-listen-on-ipv6-by-default.sh
+++ b/mainline/debian/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/mainline/debian/15-local-resolvers.envsh
+++ b/mainline/debian/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/mainline/debian/20-envsubst-on-templates.sh
+++ b/mainline/debian/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/mainline/debian/30-tune-worker-processes.sh
+++ b/mainline/debian/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/mainline/debian/docker-entrypoint.sh
+++ b/mainline/debian/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -77,6 +77,6 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi

--- a/stable/alpine-slim/10-listen-on-ipv6-by-default.sh
+++ b/stable/alpine-slim/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/stable/alpine-slim/15-local-resolvers.envsh
+++ b/stable/alpine-slim/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/stable/alpine-slim/20-envsubst-on-templates.sh
+++ b/stable/alpine-slim/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/stable/alpine-slim/30-tune-worker-processes.sh
+++ b/stable/alpine-slim/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/stable/alpine-slim/Dockerfile
+++ b/stable/alpine-slim/Dockerfile
@@ -79,9 +79,9 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in gettext so we can get `envsubst`, then throw
 # the rest away. To do this, we need to install `gettext`
 # then move `envsubst` out of the way so `gettext` can

--- a/stable/alpine-slim/docker-entrypoint.sh
+++ b/stable/alpine-slim/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -81,8 +81,8 @@ RUN set -x \
 # remove checksum deps
     && apk del --no-network .checksum-deps \
 # if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-    && if [ -n "$tempDir" ]; then rm -rf "$tempDir"; fi \
-    && if [ -n "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
-    && if [ -n "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
+    && if [ -f "$tempDir" ]; then rm -rf "$tempDir"; fi \
+    && if [ -f "/etc/apk/keys/abuild-key.rsa.pub" ]; then rm -f /etc/apk/keys/abuild-key.rsa.pub; fi \
+    && if [ -f "/etc/apk/keys/nginx_signing.rsa.pub" ]; then rm -f /etc/apk/keys/nginx_signing.rsa.pub; fi \
 # Bring in curl and ca-certificates to make registering on DNS SD easier
     && apk add --no-cache curl ca-certificates

--- a/stable/debian/10-listen-on-ipv6-by-default.sh
+++ b/stable/debian/10-listen-on-ipv6-by-default.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-ME=$(basename $0)
+ME=$(basename "$0")
 DEFAULT_CONF_FILE="etc/nginx/conf.d/default.conf"
 
 # check if we have ipv6 available

--- a/stable/debian/15-local-resolvers.envsh
+++ b/stable/debian/15-local-resolvers.envsh
@@ -8,4 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-export NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+export NGINX_LOCAL_RESOLVERS

--- a/stable/debian/20-envsubst-on-templates.sh
+++ b/stable/debian/20-envsubst-on-templates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ME=$(basename $0)
+ME=$(basename "$0")
 
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
@@ -44,8 +44,8 @@ auto_envsubst() {
     return 0
   fi
   find "$template_dir" -follow -type f -name "*$suffix" -print | while read -r template; do
-    relative_path="${template#$template_dir/}"
-    output_path="$output_dir/${relative_path%$suffix}"
+    relative_path="${template#"$template_dir/"}"
+    output_path="$output_dir/${relative_path%"$suffix"}"
     subdir=$(dirname "$relative_path")
     # create a subdirectory where the template file exists
     mkdir -p "$output_dir/$subdir"
@@ -62,8 +62,8 @@ auto_envsubst() {
     fi
     add_stream_block
     find "$template_dir" -follow -type f -name "*$stream_suffix" -print | while read -r template; do
-      relative_path="${template#$template_dir/}"
-      output_path="$stream_output_dir/${relative_path%$stream_suffix}"
+      relative_path="${template#"$template_dir/"}"
+      output_path="$stream_output_dir/${relative_path%"$stream_suffix"}"
       subdir=$(dirname "$relative_path")
       # create a subdirectory where the template file exists
       mkdir -p "$stream_output_dir/$subdir"

--- a/stable/debian/30-tune-worker-processes.sh
+++ b/stable/debian/30-tune-worker-processes.sh
@@ -4,7 +4,7 @@
 set -eu
 
 LC_ALL=C
-ME=$( basename "$0" )
+ME=$(basename "$0")
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0

--- a/stable/debian/docker-entrypoint.sh
+++ b/stable/debian/docker-entrypoint.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+if [ "$1" = "nginx" ] || [ "$1" = "nginx-debug" ]; then
     if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
         entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
 


### PR DESCRIPTION
* Replace `-n` with `-f` in Alpine Linux conditional check
* Ensure shell variables are properly quoted
* Set variable before exporting to ensure it properly fails (if it fails)
* Replace obsolete `-o` conditional check with `||`