### PR TITLE
modules: Work around Alpine Linux wget struggles with github.com.

### DIFF
--- a/modules/echo/prebuild
+++ b/modules/echo/prebuild
@@ -7,6 +7,8 @@
 # not be copied from the builder image to the resulting one, so you need to
 # build them statically
 
-echo "No prebuild stage required - all dependencies are satisfied already!"
+echo "Work around Alpine's wget/403 issue with github.com by aliasing wget to busybox wget"
+apk add wget
+ln -sf /bin/busybox /usr/bin/wget
 
 exit 0


### PR DESCRIPTION
### Proposed changes

Looks like something is subtly broken or triggers GitHub bot detection on Alpine Linux wget, as all request to tarballs result in 403.

```
$ docker run -ti --rm alpine:3.18 sh -c "apk add wget && wget https://github.com/openresty/echo-nginx-module/archive/v0.62.tar.gz" fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz (1/4) Installing libunistring (1.1-r1)
(2/4) Installing libidn2 (2.3.4-r1)
(3/4) Installing pcre2 (10.42-r1)
(4/4) Installing wget (1.21.4-r0)
Executing busybox-1.36.1-r2.trigger
OK: 11 MiB in 19 packages
--2023-08-28 21:10:42--  https://github.com/openresty/echo-nginx-module/archive/v0.62.tar.gz Resolving github.com (github.com)... 192.30.255.113 Connecting to github.com (github.com)|192.30.255.113|:443... connected. HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/openresty/echo-nginx-module/tar.gz/refs/tags/v0.62 [following] --2023-08-28 21:10:43--  https://codeload.github.com/openresty/echo-nginx-module/tar.gz/refs/tags/v0.62 Resolving codeload.github.com (codeload.github.com)... 192.30.255.121 Connecting to codeload.github.com (codeload.github.com)|192.30.255.121|:443... connected. HTTP request sent, awaiting response... 403 Forbidden 2023-08-28 21:10:43 ERROR 403: Forbidden.
```

Surprisingly, busybox wget works, so let's just use that.


### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
