### PR TITLE
Add IPv6 support for local-resolvers substitution script

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -4,6 +4,7 @@ imageTests+=(
         static
         templates
         templates-resolver
+        templates-resolver-ipv6
         workers
         modules
 	'

--- a/.test/tests/templates-resolver-ipv6/expected-std-out.txt
+++ b/.test/tests/templates-resolver-ipv6/expected-std-out.txt
@@ -1,0 +1,2 @@
+example.com - OK
+ipv6 nameserver(s) present

--- a/.test/tests/templates-resolver-ipv6/run.sh
+++ b/.test/tests/templates-resolver-ipv6/run.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+[ "$DEBUG" ] && set -x
+
+set -eo pipefail
+
+# check if we have ipv6 available
+if [ ! -f "/proc/net/if_inet6" ]; then
+    exit 0
+fi
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+clientImage='buildpack-deps:buster-curl'
+# ensure the clientImage is ready and available
+if ! docker image inspect "$clientImage" &> /dev/null; then
+	docker pull "$clientImage" > /dev/null
+fi
+
+# Create a new Docker network
+nid="$(docker network create --ipv6 --subnet fd0c:7e57::/64 nginx-test-ipv6-network)"
+trap "docker network rm -f $nid > /dev/null" EXIT
+
+# Create an instance of the container-under-test
+serverImage="$("$HOME/oi/test/tests/image-name.sh" librarytest/nginx-template "$image")"
+"$HOME/oi/test/tests/docker-build.sh" "$dir" "$serverImage" <<EOD
+FROM $image
+COPY dir/server.conf.template /etc/nginx/templates/server.conf.template
+EOD
+cid="$(docker run -d --network $nid -e NGINX_ENTRYPOINT_LOCAL_RESOLVERS=true -e NGINX_MY_SERVER_NAME=example.com "$serverImage")"
+trap "docker rm -vf $cid > /dev/null" EXIT
+
+_request() {
+	local method="$1"
+	shift
+
+	local proto="$1"
+	shift
+
+	local url="${1#/}"
+	shift
+
+	if [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" != 'true' ]; then
+		echo >&2 "$image stopped unexpectedly!"
+		( set -x && docker logs "$cid" ) >&2 || true
+		false
+	fi
+
+	docker run --rm \
+		--link "$cid":nginx \
+		"$clientImage" \
+		curl -fsSL -X"$method" --connect-to '::nginx:' "$@" "$proto://example.com/$url"
+}
+
+. "$HOME/oi/test/retry.sh" '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
+
+# Check that we can request /
+_request GET http '/resolver-templates' | grep 'example.com - OK'

--- a/.test/tests/templates-resolver-ipv6/server.conf.template
+++ b/.test/tests/templates-resolver-ipv6/server.conf.template
@@ -1,0 +1,9 @@
+resolver ${NGINX_LOCAL_RESOLVERS};
+
+server {
+    listen 80;
+    server_name ${NGINX_MY_SERVER_NAME};
+    default_type text/plain;
+    location = / { return 200 'OK\n'; }
+    location / { return 200 "${NGINX_MY_SERVER_NAME} - OK\n"; }
+}

--- a/.test/tests/templates-resolver-ipv6/server.conf.template
+++ b/.test/tests/templates-resolver-ipv6/server.conf.template
@@ -2,6 +2,7 @@ resolver ${NGINX_LOCAL_RESOLVERS};
 
 server {
     listen 80;
+    listen [::]:80;
     server_name ${NGINX_MY_SERVER_NAME};
     default_type text/plain;
     location = / { return 200 'OK\n'; }

--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -8,5 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export NGINX_LOCAL_RESOLVERS

--- a/mainline/alpine-slim/15-local-resolvers.envsh
+++ b/mainline/alpine-slim/15-local-resolvers.envsh
@@ -8,5 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export NGINX_LOCAL_RESOLVERS

--- a/mainline/debian/15-local-resolvers.envsh
+++ b/mainline/debian/15-local-resolvers.envsh
@@ -8,5 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export NGINX_LOCAL_RESOLVERS

--- a/stable/alpine-slim/15-local-resolvers.envsh
+++ b/stable/alpine-slim/15-local-resolvers.envsh
@@ -8,5 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export NGINX_LOCAL_RESOLVERS

--- a/stable/debian/15-local-resolvers.envsh
+++ b/stable/debian/15-local-resolvers.envsh
@@ -8,5 +8,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
-NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export NGINX_LOCAL_RESOLVERS


### PR DESCRIPTION
### Proposed changes

When running in IPv6 networks, the `15-local-resolvers.envsh` script will create invalid nginx configuration because the IPv6 address is not wrapped in brackets as Nginx requires. This change checks for the presence of colons (which all valid IPv6 addresses should have), and wraps the address in square brackets. `/etc/resolv.conf` syntax should never present a host and port together, so it is a valid assumption that an IPv4 nameserver configuration will never have a colon present.

This is incredibly useful for getting DNS working in IPv6 Kubernetes environments.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
