### PR TITLE
Replace `COPY` with bind mount in modules examples

### DIFF
--- a/.test/tests/modules/run.sh
+++ b/.test/tests/modules/run.sh
@@ -32,7 +32,7 @@ fi
 
 # Create an instance of the container-under-test
 modulesImage="$("$HOME/oi/test/tests/image-name.sh" librarytest/nginx-template "$image")"
-DOCKER_BUILDKIT=0 docker build --build-arg NGINX_FROM_IMAGE="$image" --build-arg ENABLED_MODULES="ndk set-misc echo" -t "$modulesImage" -f "modules/$dockerfile" "$GITHUB_WORKSPACE/modules"
+docker build --build-arg NGINX_FROM_IMAGE="$image" --build-arg ENABLED_MODULES="ndk set-misc echo" -t "$modulesImage" -f "modules/$dockerfile" "$GITHUB_WORKSPACE/modules"
 
 serverImage="${modulesImage}-sme"
 "$HOME/oi/test/tests/docker-build.sh" "$dir" "$serverImage" <<EOD

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -70,12 +70,11 @@ RUN set -ex \
     && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
 FROM ${NGINX_FROM_IMAGE}
-COPY --from=builder /tmp/packages /tmp/packages
-RUN set -ex \
+RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
+    set -ex \
     && apt update \
     && . /tmp/packages/modules.env \
     && for module in $BUILT_MODULES; do \
            apt install --no-install-suggests --no-install-recommends -y /tmp/packages/nginx-module-${module}_${NGINX_VERSION}*.deb; \
        done \
-    && rm -rf /tmp/packages \
     && rm -rf /var/lib/apt/lists/

--- a/modules/Dockerfile.alpine
+++ b/modules/Dockerfile.alpine
@@ -62,10 +62,9 @@ RUN set -ex \
     && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
 FROM ${NGINX_FROM_IMAGE}
-COPY --from=builder /tmp/packages /tmp/packages
-RUN set -ex \
+RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
+    set -ex \
     && . /tmp/packages/modules.env \
     && for module in $BUILT_MODULES; do \
            apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
-       done \
-    && rm -rf /tmp/packages
+       done

--- a/modules/README.md
+++ b/modules/README.md
@@ -5,6 +5,17 @@ your own instuctions following a simple filesystem layout/syntax using
 `build_module.sh` helper script, or falling back to package sources from
 [pkg-oss](https://hg.nginx.org/pkg-oss).
 
+## Requirements
+
+To use the Dockerfiles provided here,
+[Docker BuildKit](https://docs.docker.com/build/buildkit/) is required.
+This is enabled by default as of version 23.0; for earlier versions this can be
+enabled by setting the environment variable `DOCKER_BUILDKIT` to `1`.
+
+If you can not or do not want to use BuildKit, you can use a previous version
+of these files, see for example
+https://github.com/nginxinc/docker-nginx/tree/4bf0763f4977fff7e9648add59e0540088f3ca9f/modules.
+
 ## Usage
 
 ```


### PR DESCRIPTION
### Proposed changes

In the modules examples, a `COPY` from the builder is done to ensure it's output is available to the final image. However, this operation results in the layer being part of the final image and thus slightly bloating it. 

By using a bind mount for the `RUN` operation, the builder content is exposed to this particular run operation only, in a read-only manner, and will not be part of the final image in any way.

See also https://docs.docker.com/engine/reference/builder/#run---mount.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
