### PR TITLE
Add riscv64 support

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -119,7 +119,7 @@ for version in "${versions[@]}"; do
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
-			Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
+			Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE


### PR DESCRIPTION
### Proposed changes

Since riscv64 had be adopted in alpine 3.20 (stable, released in May 22), we can add riscv64 and update alpine.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
