### PR TITLE
fix: remove trailing whitespace from awk command

### DIFF
--- a/entrypoint/15-local-resolvers.envsh
+++ b/entrypoint/15-local-resolvers.envsh
@@ -9,4 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
 NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+
+NGINX_LOCAL_RESOLVERS="${NGINX_LOCAL_RESOLVERS% }"
+
 export NGINX_LOCAL_RESOLVERS

--- a/mainline/alpine-slim/15-local-resolvers.envsh
+++ b/mainline/alpine-slim/15-local-resolvers.envsh
@@ -9,4 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
 NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+
+NGINX_LOCAL_RESOLVERS="${NGINX_LOCAL_RESOLVERS% }"
+
 export NGINX_LOCAL_RESOLVERS

--- a/mainline/debian/15-local-resolvers.envsh
+++ b/mainline/debian/15-local-resolvers.envsh
@@ -9,4 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
 NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+
+NGINX_LOCAL_RESOLVERS="${NGINX_LOCAL_RESOLVERS% }"
+
 export NGINX_LOCAL_RESOLVERS

--- a/stable/alpine-slim/15-local-resolvers.envsh
+++ b/stable/alpine-slim/15-local-resolvers.envsh
@@ -9,4 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
 NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+
+NGINX_LOCAL_RESOLVERS="${NGINX_LOCAL_RESOLVERS% }"
+
 export NGINX_LOCAL_RESOLVERS

--- a/stable/debian/15-local-resolvers.envsh
+++ b/stable/debian/15-local-resolvers.envsh
@@ -9,4 +9,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 [ "${NGINX_ENTRYPOINT_LOCAL_RESOLVERS:-}" ] || return 0
 
 NGINX_LOCAL_RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+
+NGINX_LOCAL_RESOLVERS="${NGINX_LOCAL_RESOLVERS% }"
+
 export NGINX_LOCAL_RESOLVERS


### PR DESCRIPTION
* trailing whitespaces break configs that use quotation marks around vars. See https://github.com/nginxinc/docker-nginx-unprivileged/issues/234

### Proposed changes

Currently the awk command in `entrypoint/15-local-resolvers.envsh` will always produce a trailing whitespace.
This will break configs that make use of quotation marks around variable in config templates.
Initially opened the issue here: https://github.com/nginxinc/docker-nginx-unprivileged/issues/234

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [ ] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
