### PR TITLE
Use Alpine-related commit for detecting version in `generate-stackbrew-library.sh`

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -107,6 +107,7 @@ for version in "${versions[@]}"; do
 	done
 
 
+	commit="$(dirCommit "$version/alpine-slim")"
 	alpineVersion="$(git show "$commit":"$version/alpine-slim/Dockerfile" | awk -F: '$1 == "FROM alpine" { print $2; exit }')"
 
 	for variant in alpine alpine-perl alpine-slim; do


### PR DESCRIPTION
### Proposed changes

When reviewing https://github.com/docker-library/official-images/pull/17368, I noticed it still incorrectly uses Alpine 3.19 in the generated list of tags for the new images. This is due to the commit being used to check for the Alpine version is inherited from earlier in the script, with it being the last commit that alters the Debian variant.

This PR updates the script to use the latest commit altering the Alpine (slim) image Dockerfile to correctly detect the current used Alpine version.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
