### PR TITLE
Use packaging sources to build packages on non-mainstream architectures.

### DIFF
--- a/Dockerfile-debian-otel.template
+++ b/Dockerfile-debian-otel.template
@@ -15,24 +15,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] %%PACKAGEREPO%% %%DEBIAN_VERSION%% nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y %%BUILDTARGET%% \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile %%BUILDTARGET%% \
+                && REVISION="%%REVISION%%" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="%%PKGOSSCHECKSUM%% *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in %%BUILDTARGET%%; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make %%BUILDTARGET%% \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/Dockerfile-debian-perl.template
+++ b/Dockerfile-debian-perl.template
@@ -13,24 +13,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] %%PACKAGEREPO%% %%DEBIAN_VERSION%% nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y %%BUILDTARGET%% \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile %%BUILDTARGET%% \
+                && REVISION="%%REVISION%%" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="%%PKGOSSCHECKSUM%% *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in %%BUILDTARGET%%; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make %%BUILDTARGET%% \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -43,24 +43,46 @@ RUN set -x \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] %%PACKAGEREPO%% %%DEBIAN_VERSION%% nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y %%BUILDTARGET%% \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile %%BUILDTARGET%% \
+                && REVISION="%%REVISION%%" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="%%PKGOSSCHECKSUM%% *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in %%BUILDTARGET%%; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make %%BUILDTARGET%% \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/mainline/debian-otel/Dockerfile
+++ b/mainline/debian-otel/Dockerfile
@@ -26,24 +26,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y nginx-module-otel \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile nginx-module-otel \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="b9fbdf1779186fc02aa59dd87597fe4e906892391614289a4e6eedba398a3e770347b5b07110cca8c11fa3ba85bb711626ae69832e74c69ca8340d040a465907 *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in module-otel; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make module-otel \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -24,24 +24,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y nginx-module-perl=${NGINX_VERSION}-${DYNPKG_RELEASE} \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile nginx-module-perl=${NGINX_VERSION}-${DYNPKG_RELEASE} \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="b9fbdf1779186fc02aa59dd87597fe4e906892391614289a4e6eedba398a3e770347b5b07110cca8c11fa3ba85bb711626ae69832e74c69ca8340d040a465907 *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in module-perl; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make module-perl \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -53,24 +53,46 @@ RUN set -x \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y $nginxPackages \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile $nginxPackages \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="b9fbdf1779186fc02aa59dd87597fe4e906892391614289a4e6eedba398a3e770347b5b07110cca8c11fa3ba85bb711626ae69832e74c69ca8340d040a465907 *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in base module-geoip module-image-filter module-njs module-xslt; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make base module-geoip module-image-filter module-njs module-xslt \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/stable/debian-otel/Dockerfile
+++ b/stable/debian-otel/Dockerfile
@@ -26,24 +26,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y nginx-module-otel \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile nginx-module-otel \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="825f610c44dfb97166112e6d060c0ba209a74f50e42c7c23a5b8742f468596f110bb1b4ca9299547a8a3d41f3a7caa864622f40f6c7bb4d8bab3d24880bdfb6a *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in module-otel; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make module-otel \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/stable/debian-perl/Dockerfile
+++ b/stable/debian-perl/Dockerfile
@@ -24,24 +24,46 @@ RUN set -x; \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y nginx-module-perl=${NGINX_VERSION}-${DYNPKG_RELEASE} \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile nginx-module-perl=${NGINX_VERSION}-${DYNPKG_RELEASE} \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="825f610c44dfb97166112e6d060c0ba209a74f50e42c7c23a5b8742f468596f110bb1b4ca9299547a8a3d41f3a7caa864622f40f6c7bb4d8bab3d24880bdfb6a *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in module-perl; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make module-perl \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -53,24 +53,46 @@ RUN set -x \
             ;; \
         *) \
 # we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
-            \
+# let's build binaries from the published packaging sources
 # new directory for storing sources and .deb files
-            && tempDir="$(mktemp -d)" \
+            tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \
 # (777 to ensure APT's "_apt" user can access it too)
             \
 # save list of currently-installed packages so build dependencies can be cleanly removed later
             && savedAptMark="$(apt-mark showmanual)" \
             \
-# build .deb files from upstream's source packages (which are verified by apt-get)
+# build .deb files from upstream's packaging sources
             && apt-get update \
-            && apt-get build-dep -y $nginxPackages \
+            && apt-get install --no-install-recommends --no-install-suggests -y \
+                curl \
+                devscripts \
+                equivs \
+                git \
+                libxml2-utils \
+                lsb-release \
+                xsltproc \
             && ( \
                 cd "$tempDir" \
-                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-                    apt-get source --compile $nginxPackages \
+                && REVISION="${NGINX_VERSION}-${PKG_RELEASE}" \
+                && REVISION=${REVISION%~*} \
+                && curl -f -O https://hg.nginx.org/pkg-oss/archive/${REVISION}.tar.gz \
+                && PKGOSSCHECKSUM="825f610c44dfb97166112e6d060c0ba209a74f50e42c7c23a5b8742f468596f110bb1b4ca9299547a8a3d41f3a7caa864622f40f6c7bb4d8bab3d24880bdfb6a *${REVISION}.tar.gz" \
+                && if [ "$(openssl sha512 -r ${REVISION}.tar.gz)" = "$PKGOSSCHECKSUM" ]; then \
+                    echo "pkg-oss tarball checksum verification succeeded!"; \
+                else \
+                    echo "pkg-oss tarball checksum verification failed!"; \
+                    exit 1; \
+                fi \
+                && tar xzvf ${REVISION}.tar.gz \
+                && cd pkg-oss-${REVISION} \
+                && cd debian \
+                && for target in base module-geoip module-image-filter module-njs module-xslt; do \
+                    make rules-$target; \
+                    mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes" \
+                        debuild-$target/nginx-$NGINX_VERSION/debian/control; \
+                done \
+                && make base module-geoip module-image-filter module-njs module-xslt \
             ) \
 # we don't remove APT lists here because they get re-downloaded and removed later
             \

--- a/update.sh
+++ b/update.sh
@@ -179,23 +179,17 @@ get_buildtarget() {
         alpine-slim)
             echo base
             ;;
-        alpine-perl)
-            echo module-perl
-            ;;
-        alpine-otel)
-            echo module-otel
-            ;;
         alpine)
             echo module-geoip module-image-filter module-njs module-xslt
             ;;
         debian)
-            echo "\$nginxPackages"
+            echo base module-geoip module-image-filter module-njs module-xslt
             ;;
-        debian-perl)
-            echo "nginx-module-perl=\${NGINX_VERSION}-\${DYNPKG_RELEASE}"
+        *-perl)
+            echo module-perl
             ;;
-        debian-otel)
-            echo "nginx-module-otel"
+        *-otel)
+            echo module-otel
             ;;
     esac
 }


### PR DESCRIPTION
### Proposed changes

Similarly to what's currently happening on Alpine, use pkg-oss sources to build packages from source on Debian.  This allows us to provide fixes for architectures not covered by upstream nginx.org packages (amd64, aarch64) without touching the rest of infrastructure on nginx.org.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/docker-nginx/blob/master/CONTRIBUTING.md) document
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
