### PR TITLE
Fix FromAsCasing warning

### DIFF
--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -1,5 +1,5 @@
 ARG NGINX_FROM_IMAGE=nginx:mainline
-FROM ${NGINX_FROM_IMAGE} as builder
+FROM ${NGINX_FROM_IMAGE} AS builder
 
 ARG ENABLED_MODULES
 

--- a/modules/Dockerfile.alpine
+++ b/modules/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG NGINX_FROM_IMAGE=nginx:mainline-alpine
-FROM ${NGINX_FROM_IMAGE} as builder
+FROM ${NGINX_FROM_IMAGE} AS builder
 
 ARG ENABLED_MODULES
 


### PR DESCRIPTION
Docker complains about FROM ${NGINX_FROM_IMAGE} as builder because `'as' and 'FROM' keywords' casing do not match` [info](https://docs.docker.com/reference/build-checks/from-as-casing/).

Super simple fix. Absolutely a minor fix, but it's one less warning.