### PR TITLE
Update mainline to Alpine 3.23

### DIFF
--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-FROM alpine:3.22
+FROM alpine:3.23
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 

--- a/update.sh
+++ b/update.sh
@@ -55,7 +55,7 @@ declare -A debian=(
 )
 
 declare -A alpine=(
-    [mainline]='3.22'
+    [mainline]='3.23'
     [stable]='3.21'
 )
 


### PR DESCRIPTION
### Proposed changes

Updates the mainline image to use Alpine 3.23 as default version. See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.23.0.

Note: given that this requires built binaries for the new Alpine version and won't take any effect until an actual new release of `nginx` itself, this PR is intentionally marked as draft, so it can function both as a heads-up about the new release and a place that allows for subscription to any potential updates. It can then be merged later at any convenient time when everything is ready. However, if it is still preferable to close this in the meantime, feel free to do so.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
