### PR TITLE
Add label org.opencontainers.image.source

### DIFF
--- a/Dockerfile-alpine-otel.template
+++ b/Dockerfile-alpine-otel.template
@@ -1,5 +1,7 @@
 FROM nginx:%%NGINX_VERSION%%-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION   %%OTEL_VERSION%%
 
 RUN set -x \

--- a/Dockerfile-alpine-perl.template
+++ b/Dockerfile-alpine-perl.template
@@ -1,5 +1,7 @@
 FROM nginx:%%NGINX_VERSION%%-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x \
     && apkArch="$(cat /etc/apk/arch)" \
     && nginxPackages="%%PACKAGES%%

--- a/Dockerfile-alpine-slim.template
+++ b/Dockerfile-alpine-slim.template
@@ -1,6 +1,7 @@
 FROM alpine:%%ALPINE_VERSION%%
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION  %%NGINX_VERSION%%
 ENV PKG_RELEASE    %%PKG_RELEASE%%

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,7 @@
 FROM nginx:%%NGINX_VERSION%%-alpine-slim
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV NJS_VERSION   %%NJS_VERSION%%
 ENV NJS_RELEASE   %%NJS_RELEASE%%
 

--- a/Dockerfile-debian-otel.template
+++ b/Dockerfile-debian-otel.template
@@ -1,5 +1,7 @@
 FROM nginx:%%NGINX_VERSION%%
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION     %%OTEL_VERSION%%
 
 RUN set -x; \

--- a/Dockerfile-debian-perl.template
+++ b/Dockerfile-debian-perl.template
@@ -1,5 +1,7 @@
 FROM nginx:%%NGINX_VERSION%%
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x; \
     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg; \
     dpkgArch="$(dpkg --print-architecture)" \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,6 +1,7 @@
 FROM debian:%%DEBIAN_VERSION%%-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION   %%NGINX_VERSION%%
 ENV NJS_VERSION     %%NJS_VERSION%%

--- a/mainline/alpine-otel/Dockerfile
+++ b/mainline/alpine-otel/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.29.4-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION   0.1.2
 
 RUN set -x \

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.29.4-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x \
     && apkArch="$(cat /etc/apk/arch)" \
     && nginxPackages=" \

--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -6,6 +6,7 @@
 FROM alpine:3.23
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION  1.29.4
 ENV PKG_RELEASE    1

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.29.4-alpine-slim
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV NJS_VERSION   0.9.4
 ENV NJS_RELEASE   1
 

--- a/mainline/debian-otel/Dockerfile
+++ b/mainline/debian-otel/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.29.4
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION     0.1.2
 
 RUN set -x; \

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.29.4
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x; \
     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg; \
     dpkgArch="$(dpkg --print-architecture)" \

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -6,6 +6,7 @@
 FROM debian:trixie-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION   1.29.4
 ENV NJS_VERSION     0.9.4

--- a/modules/Dockerfile
+++ b/modules/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update \
     && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
 FROM ${NGINX_FROM_IMAGE}
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
     apt-get update \
     && . /tmp/packages/modules.env \

--- a/modules/Dockerfile.alpine
+++ b/modules/Dockerfile.alpine
@@ -62,6 +62,7 @@ RUN apk update \
     && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
 FROM ${NGINX_FROM_IMAGE}
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
     . /tmp/packages/modules.env \
     && for module in $BUILT_MODULES; do \

--- a/stable/alpine-otel/Dockerfile
+++ b/stable/alpine-otel/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.28.0-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION   0.1.2
 
 RUN set -x \

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.28.0-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x \
     && apkArch="$(cat /etc/apk/arch)" \
     && nginxPackages=" \

--- a/stable/alpine-slim/Dockerfile
+++ b/stable/alpine-slim/Dockerfile
@@ -6,6 +6,7 @@
 FROM alpine:3.21
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION  1.28.0
 ENV PKG_RELEASE    1

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.28.0-alpine-slim
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV NJS_VERSION   0.8.10
 ENV NJS_RELEASE   1
 

--- a/stable/debian-otel/Dockerfile
+++ b/stable/debian-otel/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.28.0
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 ENV OTEL_VERSION     0.1.2
 
 RUN set -x; \

--- a/stable/debian-perl/Dockerfile
+++ b/stable/debian-perl/Dockerfile
@@ -5,6 +5,8 @@
 #
 FROM nginx:1.28.0
 
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
+
 RUN set -x; \
     NGINX_GPGKEY_PATH=/etc/apt/keyrings/nginx-archive-keyring.gpg; \
     dpkgArch="$(dpkg --print-architecture)" \

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -6,6 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+LABEL org.opencontainers.image.source="https://github.com/nginx/nginx"
 
 ENV NGINX_VERSION   1.28.0
 ENV NJS_VERSION     0.8.10


### PR DESCRIPTION
### Proposed changes

Add label `org.opencontainers.image.source` to all templates in order for renovate and dependabot to fetch release notes for docker container updates.
https://docs.renovatebot.com/modules/datasource/docker/#description

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
