### PR TITLE
Fix PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Describe the use case and detail of the change. If this PR addresses an issue on
 
 Before creating a PR, run through this checklist and mark each as complete:
 
-- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/nginx/docker-nginx/blob/master/CONTRIBUTING.md)
 - [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
 - [ ] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
 - [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
 - [ ] If applicable, I have checked that any relevant tests pass after adding my changes
-- [ ] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
+- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/docker-nginx/blob/master/README.md) and/or [`modules/README.md`](https://github.com/nginx/docker-nginx/blob/master/modules/README.md))


### PR DESCRIPTION
### Proposed changes

The links in the PR template are not working as supposed to do.
`I have read the [contributing guidelines](/CONTRIBUTING.md)` links to `https://www.github.careers/careers-home` instead, which is funny, but not helpful. The path is wrong there.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run `./update.sh` and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`modules/README.md`](/modules/README.md))
