### PR TITLE
Drop arm32v6 for Alpine-derived images

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -21,8 +21,8 @@ debian_architectures=(
 
 declare -A alpine_architectures
 alpine_architectures=(
-	[mainline]='arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64'
-	[stable]='arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64'
+	[mainline]='arm64v8, arm32v7, ppc64le, s390x, i386, amd64, riscv64'
+	[stable]='arm64v8, arm32v7, ppc64le, s390x, i386, amd64, riscv64'
 )
 
 


### PR DESCRIPTION
### Proposed changes

DOI infra seems to struggle with building Rust-based acme module for
this specific target.

Given that Debian builds for the same images are built just fine, users
of said devices (Raspberry Pi 0 and Raspberry Pi 1) have a
migration path to the newer NGINX versions.

An alternative is to introduce additional branching in
update.sh/Dockerfile templates, but that seems excessive just to support
this particular target with a limited number of real world users.

cc @yosifkit @tianon 