### PR TITLE
sync workflow: limit to upstream repo

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,6 +12,7 @@ defaults:
 jobs:
   sync-awsecr:
     name: Sync Docker Hub to AWS ECR Public
+    if: ${{ github.repository == 'nginx/docker-nginx' }}
     runs-on: ubuntu-24.04
     permissions:
       id-token: write


### PR DESCRIPTION
### Proposed changes

This PR limits sync repository to `nginx/docker-nginx` repo as it does not make sense anywhere else.