### PR TITLE
Fixes to make Sync to AWS ECR work again

### DIFF
--- a/sync-awsecr.sh
+++ b/sync-awsecr.sh
@@ -167,17 +167,11 @@ done
 done
 
 echo
-echo "# manifesting stuff"
+echo "# manifesting and pushing stuff"
 for tag in ${pulllist[@]} ${!taglist[@]}; do
-    string="docker manifest create --amend $registry/$tag"
+    string="docker buildx imagetools create --progress=plain -t --amend $registry/$tag"
     for arch in ${architectures[@]}; do
         string+=" $registry/$tag-$arch"
     done
     echo $string
-done
-
-echo
-echo "# pushing manifests"
-for tag in ${pulllist[@]} ${!taglist[@]}; do
-    echo "docker manifest push --purge $registry/$tag"
 done


### PR DESCRIPTION
### Proposed changes

This PR fixes image syncs to AWS ECR Public, broken recently by Docker v29 updates on GitHub actions runner infrastructure.  Previously, in Docker v28, we were able to create manifests by skipping the annotation parts;  this no longer works in v29.  The solution is to migrate to `buildx imagetools`.

On top of that, move tabs to spaces to be consistent with other scripts in the repo, and add `otel` image to the sync.